### PR TITLE
OSD-182: resize logo after adding new one on assembly

### DIFF
--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme) => ({
   paper: theme.paper.paper,
   logo: {
     maxHeight: 100,
+    width: 100
   },
 }));
 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OSD-182
part of TICKET: https://openimis.atlassian.net/browse/OP-785

RELATED PR: https://github.com/openimis/openimis-fe_js/pull/63

After this change it should look like below:
![Screenshot from 2022-05-27 12-34-24](https://user-images.githubusercontent.com/52816247/170684148-8c061007-6a26-40cb-90be-d377c53f1276.png)
the logo from demo to compare:
![Screenshot from 2022-05-27 12-34-14](https://user-images.githubusercontent.com/52816247/170684175-24f0e10f-16c8-4bbe-9d5c-5202065e4f0b.png)

