### PR TITLE
OP-835: Extend table for functional headers

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -237,7 +237,15 @@ class Table extends Component {
                           justifyContent={aligns.length > idx ? aligns[idx] : "left"}
                         >
                           <Box>
+                            {typeof h === 'function' ? (
+                              <Box>
+                              {() => (h(this.state, this.props))}
+                              </Box>
+                            ): ( 
                             <FormattedMessage module={module} id={h} />
+                            ) 
+                            }
+                           
                           </Box>
                           {headerActions.length > idx ? this.headerAction(headerActions[idx][1]) : null}
                         </Box>


### PR DESCRIPTION
Additional functionality allowing functions as headers. 
Part of [OP-835](https://openimis.atlassian.net/browse/OP-835)