### PR TITLE
OTC-748 Added support for custom api url

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -27,7 +27,15 @@ const LANGUAGE_FULL_PROJECTION = () => ["name", "code", "sortOrder"];
 
 const MODULEPERMISSION_FULL_PROJECTION = () => ["modulePermsList{moduleName, permissions{permsName, permsValue}}"];
 
-export const baseApiUrl =  "/api";
+function getApiUrl() {
+  let _baseApiUrl = process.env.REACT_APP_API_URL ?? '/api';
+  if (_baseApiUrl.indexOf('/') !== 0) {
+    _baseApiUrl = `/${_baseApiUrl}`;
+  }
+  return _baseApiUrl;
+}
+
+export const baseApiUrl = getApiUrl();
 
 export function apiHeaders() {
   let headers = {


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-748](https://openimis.atlassian.net/browse/OTC-748)

Changes:
- Added an option to overrige default `/api` backend root with a custom one with `REACT_APP_API_URL`. This is done at build time and cannot be updated at runtime.