### PR TITLE
OP-1037: Adding possibility to enter more than 1 arg to query

### DIFF
--- a/src/components/inputs/ValidatedTextInput.js
+++ b/src/components/inputs/ValidatedTextInput.js
@@ -29,6 +29,7 @@ const ValidatedTextInput = ({
   value,
   shouldValidate,
   itemQueryIdentifier,
+  additionalQueryArgs,
 }) => {
   const modulesManager = useModulesManager();
   const classes = useStyles();
@@ -41,6 +42,7 @@ const ValidatedTextInput = ({
   useEffect(() => {
     if (shouldBeValidated) {
       queryVariables[itemQueryIdentifier] = value;
+      if (additionalQueryArgs) Object.entries(additionalQueryArgs).map((arg) => (queryVariables[arg?.[0]] = arg?.[1]));
       if (value) checkValidity(queryVariables);
       return () => (!value || isValid) && dispatch(clearAction());
     } else {


### PR DESCRIPTION
Part of [POLICY PR](https://github.com/openimis/openimis-fe-policy_js/pull/27)
Part of [CONTRIBUTION PR](https://github.com/openimis/openimis-fe-contribution_js/pull/7)

In scope of this PR, I implemented the possibility to pass more than one argument as a query identifier. Currently, we can pass as many arguments as we need, it is enough to put them into _additionalQueryArgs_ object.