### PR TITLE
OTC-884: Disabled save button in role management fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -440,3 +440,9 @@ export function roleNameValidationClear() {
     dispatch({ type: `CORE_ROLE_NAME_VALIDATION_FIELDS_CLEAR` });
   };
 }
+
+export function roleNameSetValid() {
+  return (dispatch) => {
+    dispatch({ type: `CORE_ROLE_NAME_VALIDATION_FIELDS_SET_VALID` });
+  };
+}

--- a/src/components/RoleHeadPanel.js
+++ b/src/components/RoleHeadPanel.js
@@ -1,24 +1,23 @@
-import React, {Fragment} from "react";
-import {formatMessage, FormattedMessage, FormPanel, TextInput, withModulesManager} from "@openimis/fe-core";
-import {Checkbox, Divider, FormControlLabel, Grid} from "@material-ui/core";
-import {injectIntl} from "react-intl";
-import {withStyles, withTheme} from "@material-ui/core/styles";
-import {ValidatedTextInput} from "../index";
+import React, { Fragment } from "react";
+import { formatMessage, FormattedMessage, FormPanel, TextInput, withModulesManager } from "@openimis/fe-core";
+import { Checkbox, Divider, FormControlLabel, Grid } from "@material-ui/core";
+import { withStyles, withTheme } from "@material-ui/core/styles";
+import { ValidatedTextInput } from "../index";
 import { connect } from "react-redux";
-import {roleNameValidationCheck, roleNameValidationClear} from "../actions";
+import { roleNameValidationCheck, roleNameValidationClear, roleNameSetValid } from "../actions";
 
 const styles = (theme) => ({
   item: theme.paper.item,
 });
 
 class RoleHeadPanel extends FormPanel {
-
   shouldValidate = (inputValue) => {
     const { savedRoleName } = this.props;
     return inputValue !== savedRoleName;
   };
   render() {
-    const { intl, classes, edited, isRequiredFieldsEmpty, isReadOnly, isRoleNameValid, roleNameValidationError } = this.props;
+    const { intl, classes, edited, isRequiredFieldsEmpty, isReadOnly, isRoleNameValid, roleNameValidationError } =
+      this.props;
     return (
       <Fragment>
         <Divider />
@@ -40,6 +39,7 @@ class RoleHeadPanel extends FormPanel {
               validationError={roleNameValidationError}
               action={roleNameValidationCheck}
               clearAction={roleNameValidationClear}
+              setValidAction={roleNameSetValid}
               module="core"
               label="roleManagement.roleName"
               value={!!edited && !!edited.name ? edited.name : ""}
@@ -88,10 +88,10 @@ class RoleHeadPanel extends FormPanel {
 }
 
 const mapStateToProps = (state) => ({
-    isRoleNameValid: state.core.validationFields?.roleName?.isValid,
-    isRoleNameValidating: state.core.validationFields?.roleName?.isValidating,
-    roleNameValidationError: state.core.validationFields?.roleName?.validationError,
-    savedRoleName: state.core?.role?.name,
-  });
+  isRoleNameValid: state.core.validationFields?.roleName?.isValid,
+  isRoleNameValidating: state.core.validationFields?.roleName?.isValidating,
+  roleNameValidationError: state.core.validationFields?.roleName?.validationError,
+  savedRoleName: state.core?.role?.name,
+});
 
 export default withModulesManager(connect(mapStateToProps)(withTheme(withStyles(styles)(RoleHeadPanel))));

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -244,7 +244,8 @@ function reducer(
         ...state,
         fetchingRoleRights: false,
         errorRoleRights: formatServerError(action.payload),
-      };case "CORE_ROLE_NAME_VALIDATION_FIELDS_REQ":
+      };
+    case "CORE_ROLE_NAME_VALIDATION_FIELDS_REQ":
       return {
         ...state,
         validationFields: {
@@ -253,9 +254,9 @@ function reducer(
             isValidating: true,
             isValid: false,
             validationError: null,
+          },
         },
-      },
-    };
+      };
     case "CORE_ROLE_NAME_VALIDATION_FIELDS_RESP":
       return {
         ...state,
@@ -265,9 +266,9 @@ function reducer(
             isValidating: false,
             isValid: action.payload?.data.isValid,
             validationError: formatGraphQLError(action.payload),
+          },
         },
-      },
-    };
+      };
     case "CORE_ROLE_NAME_VALIDATION_FIELDS_ERR":
       return {
         ...state,
@@ -277,9 +278,9 @@ function reducer(
             isValidating: false,
             isValid: false,
             validationError: formatServerError(action.payload),
+          },
         },
-      },
-    };
+      };
     case "CORE_ROLE_NAME_VALIDATION_FIELDS_CLEAR":
       return {
         ...state,
@@ -289,9 +290,21 @@ function reducer(
             isValidating: true,
             isValid: false,
             validationError: null,
+          },
         },
-      },
-    };
+      };
+    case "CORE_ROLE_NAME_VALIDATION_FIELDS_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          roleName: {
+            isValidating: false,
+            isValid: true,
+            validationError: null,
+          },
+        },
+      };
     case "CORE_ROLE_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "CORE_ROLE_MUTATION_ERR":


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of isValid by adding an extra action, which sets the state properly when we're editing a name of role for the first time. Moreover, there was an issue when we paste an invalid role name and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ