### PR TITLE
OTC-873: Adding type prop, readOnly fix

### DIFF
--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -56,6 +56,7 @@ class TextInput extends Component {
       inputProps = {},
       formatInput = null,
       helperText,
+      type,
       ...others
     } = this.props;
     return (
@@ -72,6 +73,7 @@ class TextInput extends Component {
         value={this.state.value}
         error={Boolean(error)}
         helperText={error ?? helperText}
+        type={type}
       />
     );
   }

--- a/src/components/inputs/ValidatedTextInput.js
+++ b/src/components/inputs/ValidatedTextInput.js
@@ -12,26 +12,27 @@ import { useStyles } from "../../styles";
 import { DEFAULT_DEBOUNCE_TIME } from "../../constants";
 
 const ValidatedTextInput = ({
-  autoFocus,
   action,
-  setValidAction,
+  additionalQueryArgs,
+  autoFocus,
   className,
   clearAction,
   codeTakenLabel,
   inputProps,
   isValid,
   isValidating,
+  itemQueryIdentifier,
   label,
   module,
   onChange,
   placeholder,
   readOnly,
   required,
+  setValidAction,
+  shouldValidate,
+  type,
   validationError,
   value,
-  shouldValidate,
-  itemQueryIdentifier,
-  additionalQueryArgs,
 }) => {
   const modulesManager = useModulesManager();
   const classes = useStyles();
@@ -60,10 +61,11 @@ const ValidatedTextInput = ({
           module={module}
           autoFocus={autoFocus}
           className={className}
-          disabled={readOnly}
+          readOnly={readOnly}
           required={required}
           label={label}
           placeholder={placeholder}
+          type={type}
           error={validationError || (!isValidating && !isValid && value) ? formatMessage(codeTakenLabel) : null}
           value={value}
           inputProps={inputProps}
@@ -93,6 +95,7 @@ const ValidatedTextInput = ({
           value={value}
           readOnly={readOnly}
           required={required}
+          type={type}
           onChange={debounce(onChange, DEFAULT_DEBOUNCE_TIME)}
           inputProps={inputProps}
           endAdornment={


### PR DESCRIPTION
[OTC-873](https://openimis.atlassian.net/browse/OTC-873)

RELATED [ADMIN PR](https://github.com/openimis/openimis-fe-admin_js/pull/49)

In scope of this ticket, I added the possibility to pass a prop _type_. While working on this, I also fixed readOnly property. Now, it blocks the validation field after save.

[OTC-873]: https://openimis.atlassian.net/browse/OTC-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ