### PR TITLE
OTC-786: SelectDialog implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 - `JournalDrawer`: side bar in which mutation journal is displayed
 - `AlertDialog`: pop up (modal) dialog to display an alert message (one 'ok' button)
 - `ConfirmDialog`: pop up (modal) dialog to display a confirmation message (with 'cancel' / 'confirm' buttons)
+- `SelectDialog`: pop up (modal) dialog to display a message and take an action between two options (yes/no, do/do not, continue/go back) - with editable (through the props) button labels, message content and dialog title, without using Redux store and actions
 - `FataError`: page for non-recoverable backend access errors
 - `Help`: main menu entry for Help (link to manual)
 - `Logout`: main menu entry to logout

--- a/src/components/dialogs/SelectDialog.js
+++ b/src/components/dialogs/SelectDialog.js
@@ -1,0 +1,44 @@
+import React from "react";
+import { injectIntl } from "react-intl";
+
+import { withTheme, withStyles } from "@material-ui/core/styles";
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@material-ui/core";
+import { useTranslations, useModulesManager } from "@openimis/fe-core";
+
+const styles = (theme) => ({
+  primaryButton: theme.dialog.primaryButton,
+  secondaryButton: theme.dialog.secondaryButton,
+});
+
+const SelectDialog = ({
+  classes,
+  module,
+  confirmationButton,
+  rejectionButton,
+  confirmMessage,
+  confirmState,
+  confirmTitle,
+  onClose,
+  onConfirm,
+}) => {
+  const modulesManager = useModulesManager();
+  const { formatMessage } = useTranslations(module, modulesManager);
+  return (
+    <Dialog open={confirmState} onClose={onClose}>
+      <DialogTitle>{formatMessage(confirmTitle)}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{formatMessage(confirmMessage)}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onConfirm} autoFocus className={classes.primaryButton}>
+          {formatMessage(confirmationButton)}
+        </Button>
+        <Button onClick={onClose} className={classes.secondaryButton}>
+          {formatMessage(rejectionButton)}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default injectIntl(withTheme(withStyles(styles)(SelectDialog)));

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ import Role from "./pages/Role";
 import reducer from "./reducer";
 import ErrorBoundary from "./helpers/ErrorBoundary";
 import ConfirmDialog from "./components/dialogs/ConfirmDialog";
+import SelectDialog from "./components/dialogs/SelectDialog";
 import {
   baseApiUrl,
   apiHeaders,
@@ -242,6 +243,7 @@ export {
   SearcherExport,
   Searcher,
   SearcherPane,
+  SelectDialog,
   ConstantBasedPicker,
   ErrorBoundary,
   useTranslations,


### PR DESCRIPTION
RELATED [POLICY PR](https://github.com/openimis/openimis-fe-policy_js/pull/32)

[OTC-786](https://openimis.atlassian.net/browse/OTC-786)

In scope of this ticket:
- Implementation of the generic _SelectDialog_ - the pop up dialog to display a message and take some simple action after it. It is not using Redux store and actions. Moreover, it is fully editable - button labels, message content and title might be modified through the props.
- README has been updated - I added the description about _SelectDialog_.

[OTC-786]: https://openimis.atlassian.net/browse/OTC-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ