### PR TITLE
OTC-757: Searcher feature, clearing pagination if enetered the Roles

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -446,3 +446,15 @@ export function roleNameSetValid() {
     dispatch({ type: `CORE_ROLE_NAME_VALIDATION_FIELDS_SET_VALID` });
   };
 }
+
+export function saveCurrentPaginationPage(page, afterCursor, beforeCursor, module) {
+  return (dispatch) => {
+    dispatch({ type: "CORE_PAGINATION_PAGE", payload: { page, afterCursor, beforeCursor, module} });
+  };
+}
+
+export function clearCurrentPaginationPage() {
+  return (dispatch) => {
+    dispatch({ type: "CORE_PAGINATION_PAGE_CLEAR" })
+  }
+}

--- a/src/components/generics/Searcher.js
+++ b/src/components/generics/Searcher.js
@@ -1,9 +1,9 @@
 import React, { Component, Fragment } from "react";
-import { connect } from "react-redux";
-import { bindActionCreators } from "redux";
-import { injectIntl } from "react-intl";
 import _ from "lodash";
-import { withTheme, withStyles } from "@material-ui/core/styles";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
+import { injectIntl } from "react-intl";
+
 import {
   Grid,
   Paper,
@@ -15,17 +15,19 @@ import {
   MenuItem,
   CircularProgress,
 } from "@material-ui/core";
+import { withTheme, withStyles } from "@material-ui/core/styles";
 import MoreHoriz from "@material-ui/icons/MoreHoriz";
+
+import { cacheFilters, saveCurrentPaginationPage } from "../../actions";
+import { formatMessage } from "../../helpers/i18n";
+import { sort, formatSorter } from "../../helpers/api";
+import withModulesManager from "../../helpers/modules";
 import SearcherExport from "./SearcherExport";
 import SearcherPane from "./SearcherPane";
 import Contributions from "./Contributions";
 import FormattedMessage from "./FormattedMessage";
 import ProgressOrError from "./ProgressOrError";
 import Table from "./Table";
-import withModulesManager from "../../helpers/modules";
-import { formatMessage } from "../../helpers/i18n";
-import { sort, formatSorter } from "../../helpers/api";
-import { cacheFilters } from "../../actions";
 
 const styles = (theme) => ({
   root: {
@@ -204,6 +206,9 @@ class Searcher extends Component {
   }
 
   filtersToQueryParams = () => {
+    const { page, afterCursor, beforeCursor } = this.state;
+    const { module, saveCurrentPaginationPage } = this.props;
+    saveCurrentPaginationPage(page, afterCursor, beforeCursor, module);
     if (this.props.filtersToQueryParams) return this.props.filtersToQueryParams(this.state);
     let prms = Object.keys(this.state.filters)
       .filter((f) => !!this.state.filters[f]["filter"])
@@ -260,9 +265,9 @@ class Searcher extends Component {
   applyFilters = () => {
     this.setState(
       (state, props) => ({
-        page: 0,
-        afterCursor: null,
-        beforeCursor: null,
+        page: props.paginationPage || 0,
+        afterCursor: props.afterCursor || null,
+        beforeCursor: props.beforeCursor || null,
         clearAll: state.clearAll + 1,
       }),
       this._cacheAndApply
@@ -510,10 +515,13 @@ class Searcher extends Component {
 
 const mapStateToProps = (state) => ({
   filtersCache: !!state.core && state.core.filtersCache,
+  paginationPage: state.core?.savedPagination?.paginationPage,
+  afterCursor: state.core?.savedPagination?.afterCursor,
+  beforeCursor: state.core?.savedPagination?.beforeCursor,
 });
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ cacheFilters }, dispatch);
+  return bindActionCreators({ cacheFilters, saveCurrentPaginationPage }, dispatch);
 };
 
 export default withModulesManager(

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,3 +9,4 @@ export const RIGHT_ROLE_CREATE = 122002;
 export const RIGHT_ROLE_UPDATE = 122003;
 export const RIGHT_ROLE_DELETE = 122004;
 export const RIGHT_ROLE_DUPLICATE = 122005;
+export const MODULE_NAME = "core";

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ import {
   coreAlert,
   coreConfirm,
   fetchMutation,
-  prepareMutation
+  prepareMutation,
+  clearCurrentPaginationPage,
 } from "./actions";
 import {
   formatMessage,
@@ -174,6 +175,7 @@ export {
   downloadExport,
   coreAlert,
   coreConfirm,
+  clearCurrentPaginationPage,
   openBlob,
   sort,
   formatSorter,

--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -13,6 +13,7 @@ import {
   coreConfirm,
   journalize,
   SelectInput,
+  clearCurrentPaginationPage,
 } from "@openimis/fe-core";
 import { Grid, FormControlLabel, Checkbox, Fab, IconButton } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -183,7 +184,14 @@ class Roles extends Component {
   itemFormatters = () => {
     const { intl, rights, modulesManager, language } = this.props;
     const result = [
-      (role) => (language === null ? role.name : (language === LANGUAGE_EN ? role.name : (role.altLanguage === null ? role.name : role.altLanguage))),
+      (role) =>
+        language === null
+          ? role.name
+          : language === LANGUAGE_EN
+          ? role.name
+          : role.altLanguage === null
+          ? role.name
+          : role.altLanguage,
       (role) => (role.isSystem !== null ? <Checkbox checked={!!role.isSystem} disabled /> : ""),
       (role) => (role.isBlocked !== null ? <Checkbox checked={role.isBlocked} disabled /> : ""),
       (role) => (!!role.validityFrom ? formatDateFromISO(modulesManager, intl, role.validityFrom) : ""),
@@ -261,6 +269,12 @@ class Roles extends Component {
 
   isOnDoubleClickEnabled = (role) => !this.isRowDisabled(_, role);
 
+  componentDidMount = () => {
+    const moduleName = "core";
+    const { module } = this.props;
+    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+  };
+
   render() {
     const { intl, rights, classes, fetchingRoles, fetchedRoles, errorRoles, roles, rolesPageInfo, rolesTotalCount } =
       this.props;
@@ -317,10 +331,11 @@ const mapStateToProps = (state) => ({
   confirmed: state.core.confirmed,
   submittingMutation: state.core.submittingMutation,
   mutation: state.core.mutation,
+  module: state.core?.savedPagination?.module,
 });
 
 const mapDispatchToProps = (dispatch) => {
-  return bindActionCreators({ fetchRoles, deleteRole, coreConfirm, journalize }, dispatch);
+  return bindActionCreators({ fetchRoles, deleteRole, coreConfirm, journalize, clearCurrentPaginationPage }, dispatch);
 };
 
 export default withModulesManager(

--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -31,6 +31,7 @@ import {
   RIGHT_ROLE_DUPLICATE,
   RIGHT_ROLE_DELETE,
   QUERY_STRING_DUPLICATE,
+  MODULE_NAME,
 } from "../constants";
 import AddIcon from "@material-ui/icons/Add";
 import EditIcon from "@material-ui/icons/Edit";
@@ -270,9 +271,8 @@ class Roles extends Component {
   isOnDoubleClickEnabled = (role) => !this.isRowDisabled(_, role);
 
   componentDidMount = () => {
-    const moduleName = "core";
     const { module } = this.props;
-    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+    if (module !== MODULE_NAME) this.props.clearCurrentPaginationPage();
   };
 
   render() {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -39,6 +39,10 @@ function reducer(
     errorRoleRights: null,
     isInitialized: false,
     authError: null,
+    paginationPage: 0,
+    afterCursor: null,
+    beforeCursor: null,
+    module: null,
   },
   action,
 ) {
@@ -354,7 +358,26 @@ function reducer(
         role: null,
         roleRights: [],
       };
-
+    case "CORE_PAGINATION_PAGE":
+      return {
+        ...state,
+        savedPagination: {
+          paginationPage: action.payload?.page,
+          afterCursor: action.payload?.afterCursor,
+          beforeCursor: action.payload?.beforeCursor,
+          module: action.payload?.module,
+        },
+      };
+    case "CORE_PAGINATION_PAGE_CLEAR":
+      return {
+        ...state,
+        savedPagination: {
+          paginationPage: 0,
+          afterCursor: null,
+          beforeCursor: null,
+          module: null,
+        },
+      };
     default:
       return state;
   }


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:
- New actions and reducers to control the pagination through the Redux store.
- Saving information like current page, cursors and current module in the Redux store.
- Clearing pagination state if entered the Roles page.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ