### PR TITLE
Contribution key for unregistered routing and login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 - `core.AppBar`: ability to add entries in the AppBar (known usage: insuree Enquiry component)
 - `core.MainMenu`: ability to add main menu entries from modules (known usage: claim, insuree,...)
 - `core.Router`: ability to register routes in client-side routing (known usage: claim, insuree,...)
+- `core.UnauthenticatedRouter`: ability to register routes in client-side routing for pages that don't require user authentication
+- `core.LoginPage`: ability to add components to the menu login page
 
 ## Contributions
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,6 +20,7 @@ import SetPasswordPage from "../pages/SetPasswordPage";
 import { ErrorBoundary } from "@openimis/fe-core";
 
 export const ROUTER_CONTRIBUTION_KEY = "core.Router";
+export const UNAUTHENTICATED_ROUTER_CONTRIBUTION_KEY = "core.UnauthenticatedRouter";
 export const APP_BOOT_CONTRIBUTION_KEY = "core.Boot";
 export const TRANSLATION_CONTRIBUTION_KEY = "translations";
 
@@ -50,6 +51,10 @@ const App = (props) => {
   const auth = useAuthentication();
   const routes = useMemo(() => {
     return modulesManager.getContribs(ROUTER_CONTRIBUTION_KEY);
+  }, []);
+
+  const unauthenticatedRoutes = useMemo(() => {
+    return modulesManager.getContribs(UNAUTHENTICATED_ROUTER_CONTRIBUTION_KEY);
   }, []);
 
   const locale = useMemo(() => {
@@ -104,6 +109,18 @@ const App = (props) => {
                 <Route path={"/login"} render={() => <LoginPage {...others} />} />
                 <Route path={"/forgot_password"} render={() => <ForgotPasswordPage {...others} />} />
                 <Route path={"/set_password"} render={() => <SetPasswordPage {...others} />} />
+                {unauthenticatedRoutes.map((route) => (
+                  <Route
+                    exact
+                    key={route.path}
+                    path={"/" + route.path}
+                    render={(props) => (
+                      <ErrorBoundary>
+                          <route.component modulesManager={modulesManager} {...props} {...others} />
+                      </ErrorBoundary>
+                    )}
+                  />
+                ))}
                 {routes.map((route) => (
                   <Route
                     exact

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import { useHistory } from "../helpers/history";
 import { makeStyles } from "@material-ui/styles";
 import { Button, Box, Grid, Paper, LinearProgress } from "@material-ui/core";
@@ -7,6 +7,7 @@ import { useTranslations } from "../helpers/i18n";
 import { useModulesManager } from "../helpers/modules";
 import Helmet from "../helpers/Helmet";
 import { useAuthentication } from "../helpers/hooks";
+import Contributions from "./../components/generics/Contributions"
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -26,6 +27,8 @@ const useStyles = makeStyles((theme) => ({
     width: 100
   },
 }));
+
+const LOGIN_PAGE_CONTRIBUTION_KEY = "core.LoginPage"
 
 const LoginPage = ({ logo }) => {
   const classes = useStyles();
@@ -117,6 +120,7 @@ const LoginPage = ({ logo }) => {
                 </Grid>
                 <Grid item>
                   <Button onClick={redirectToForgotPassword}>{formatMessage("forgotPassword")}</Button>
+                  <Contributions contributionKey={LOGIN_PAGE_CONTRIBUTION_KEY} />
                 </Grid>
               </Grid>
             </Box>


### PR DESCRIPTION
This change allow registering routing for views that don't require user authentication (e.g. self registration form) and making contributions directly to the LoginPage. 