### PR TITLE
CM-107: if withLabel false display nothing

### DIFF
--- a/src/components/generics/ConstantBasedPicker.js
+++ b/src/components/generics/ConstantBasedPicker.js
@@ -66,7 +66,7 @@ class ConstantBasedPicker extends Component {
     return (
       <SelectInput
         module={module}
-        label={!!withLabel && label}
+        label={!!withLabel && label? label: " "}
         options={options}
         name={name}
         value={value}


### PR DESCRIPTION
https://openimis.atlassian.net/browse/CM-107

I fixed withLabel funcionality in the scope of above ticket. Now if withLabel false it will display no label. It used to display "false".

It has to be " " instead of "" because it somehow throws an error. " " in terms of displaying it should not be a problem to have space as something inside quotationmarks.