### PR TITLE
OP-1481: change type of number input, hide up/down arrow keys

### DIFF
--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -30,7 +30,7 @@ class NumberInput extends Component {
   };
   render() {
     const { intl, module = "core", min = null, max = null, value, error, displayZero = false, displayNa = false, decimal = false, ...others } = this.props;
-    let inputProps = { ...this.props.inputProps, type: "tel" }; // We use "tel" instead of "number" to hide up/down arrows
+    let inputProps = { ...this.props.inputProps, type: "number" };
     let err = error;
 
     if (min !== null) {

--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -8,6 +8,20 @@ const styles = (theme) => ({
   label: {
     color: theme.palette.primary.main,
   },
+  // NOTE: This is used to hide the increment/decrement arrows from the number input
+  numberInput: {
+    '& input[type=number]': {
+        '-moz-appearance': 'textfield'
+    },
+    '& input[type=number]::-webkit-outer-spin-button': {
+        '-webkit-appearance': 'none',
+        margin: 0
+    },
+    '& input[type=number]::-webkit-inner-spin-button': {
+        '-webkit-appearance': 'none',
+        margin: 0
+    }
+  },
 });
 
 class TextInput extends Component {
@@ -62,6 +76,7 @@ class TextInput extends Component {
     return (
       <TextField
         {...others}
+        className={classes.numberInput}
         fullWidth
         disabled={readOnly}
         label={!!label && formatMessage(intl, module, label)}


### PR DESCRIPTION
[OP-1481](https://openimis.atlassian.net/browse/OP-1481)

Changes:
- Change number input type to "number". Previously, there was a "tel" type which was causing some issues with resetting field when typing letters.
- Hide the increment/decrement arrows from the number input.

Demo:
(After typing '123', I'm trying to enter letters - it is not possible and it does not clear the input)
![testreset](https://github.com/openimis/openimis-fe-core_js/assets/109145288/afb7fe7a-fc59-4634-ae65-16dff8fc8132)

[OP-1481]: https://openimis.atlassian.net/browse/OP-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ