### PR TITLE
OP-1536: autoselect option if only 1 available

### DIFF
--- a/src/components/inputs/Autocomplete.js
+++ b/src/components/inputs/Autocomplete.js
@@ -44,6 +44,7 @@ const Autocomplete = (props) => {
   const { formatMessage } = useTranslations("core.Autocomplete", modulesManager);
   const [open, setOpen] = useState(false);
   const [resetKey, setResetKey] = useState(Date.now());
+  const shouldBeSelected = required && options.length === 1;
 
   const handleInputChange = useDebounceCb((searchString) => {
     setCurrentString && setCurrentString(searchString);
@@ -68,6 +69,10 @@ const Autocomplete = (props) => {
     setResetKey(Date.now());
   }, [value]);
 
+  useEffect(() => {
+    if (shouldBeSelected) onChange(options[0]);
+  }, [options?.length])
+  
   return (
     <MuiAutocomplete
       key={resetKey}
@@ -81,7 +86,7 @@ const Autocomplete = (props) => {
       openOnFocus
       blurOnSelect={!multiple}
       multiple={multiple}
-      disabled={readOnly}
+      disabled={readOnly || shouldBeSelected}
       options={options}
       loading={isLoading}
       autoHighlight={autoHighlight}

--- a/src/components/inputs/Autocomplete.js
+++ b/src/components/inputs/Autocomplete.js
@@ -72,7 +72,7 @@ const Autocomplete = (props) => {
   useEffect(() => {
     if (shouldBeSelected) onChange(options[0]);
   }, [options?.length])
-  
+
   return (
     <MuiAutocomplete
       key={resetKey}
@@ -86,7 +86,7 @@ const Autocomplete = (props) => {
       openOnFocus
       blurOnSelect={!multiple}
       multiple={multiple}
-      disabled={readOnly || shouldBeSelected}
+      disabled={readOnly}
       options={options}
       loading={isLoading}
       autoHighlight={autoHighlight}


### PR DESCRIPTION
[OP-1536](https://openimis.atlassian.net/browse/OP-1536)

[RELATED PR](https://github.com/openimis/openimis-fe-product_js/pull/62)
[RELATED PR](https://github.com/openimis/openimis-fe-policy_js/pull/58)

Changes:
- If only 1 option available in options, select this option. This feature applies to dropdowns that utilize Autocomplete under the hood. AutoSuggestion continues to function as it did prior to this change.

Officer Picker - Autocomplete component - only 1 officer available and it's selected once user enters the form: ![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/f0fdf0c0-18c3-4f09-a50e-c2d6eccbcdda)

Note: I've implemented this in a generic component, and it currently only functions for dropdowns that are marked as required. However, there are situations where certain fields are indicated as required, but the Autocomplete component is unaware of this requirement due to the way props are passed. To address this, it is essential to transmit information about whether a field is required to the Autocomplete component as well.

[OP-1536]: https://openimis.atlassian.net/browse/OP-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ