### PR TITLE
CM-293: add confluence page as url for Help component for coreMIS imp…

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -115,3 +115,6 @@ export const CLAIM_STATS_ORDER = [
   "services_passed",
   "services_rejected"
 ]
+
+export const CORE_MIS_CONFLUENCE_URL = "https://openimis.atlassian.net/wiki/spaces/OP/pages/3531407380/Project+2022.T3+CORE-MIS+Merger";
+export const DEFAULT_URL = "/Manual/IMIS_manual.pdf";

--- a/src/pages/Help.js
+++ b/src/pages/Help.js
@@ -14,7 +14,7 @@ const styles = (theme) => ({
 
 const Help = ({ classes }) => {
   const modulesManager = useModulesManager();
-  const isCoreMISHelp = modulesManager.getConf("fe-core", "help.isCoreMIS", false);
+  const isCoreMISHelp = modulesManager.getConf("fe-core", "redirectToCoreMISConfluenceUrl", false);
   const url = isCoreMISHelp ? CORE_MIS_CONFLUENCE_URL : DEFAULT_URL;
   const onClick = () => {
     window.open(url);

--- a/src/pages/Help.js
+++ b/src/pages/Help.js
@@ -2,6 +2,8 @@ import React from "react";
 import { withStyles } from "@material-ui/core/styles";
 import { IconButton } from "@material-ui/core";
 import { HelpOutline } from "@material-ui/icons";
+import { useModulesManager } from "@openimis/fe-core";
+import {CORE_MIS_CONFLUENCE_URL, DEFAULT_URL} from "../constants";
 
 const styles = (theme) => ({
   button: {
@@ -11,8 +13,11 @@ const styles = (theme) => ({
 });
 
 const Help = ({ classes }) => {
+  const modulesManager = useModulesManager();
+  const isCoreMISHelp = modulesManager.getConf("fe-core", "help.isCoreMIS", false);
+  const url = isCoreMISHelp ? CORE_MIS_CONFLUENCE_URL : DEFAULT_URL;
   const onClick = () => {
-    window.open("/Manual/IMIS_manual.pdf");
+    window.open(url);
   };
 
   return (


### PR DESCRIPTION
…lementation

https://openimis.atlassian.net/browse/CM-293

This PR depending on configuration will add different urls for Help component. 

It requires config option:

```
INSERT INTO "core_ModuleConfiguration" (id,"module","version",config,is_disabled_until,is_exposed,layer) VALUES
	 ('f2af6904-131b-420b-9837-4a82ec037b74','fe-core','1.0.0','{
 "redirectToCoreMISConfluenceUrl" : 1
}',NULL,true,'fe');
```