### PR TITLE
OP-1726: add clear button to the selectinput component

### DIFF
--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -23,6 +23,10 @@ const styles = (theme) => ({
   },
 });
 
+function EmptyComponent() {
+  return <div />;
+}
+
 class SelectInput extends Component {
   _onChange = (e) => {
     if (this.props.value !== e.target.value) {
@@ -32,6 +36,23 @@ class SelectInput extends Component {
 
   handleClear = () => {
     this.props.onChange("");
+  };
+
+  // When there is a value, we pass a dummy div to effectively hide the default dropdown icon.
+  // This allows us to make room for the clear icon without having two icons visible at the same time.
+  renderIconComponent = () => {
+    const { value } = this.props;
+    return value ? EmptyComponent : undefined;
+  };
+
+  // If there's a value, we render the clear icon. Clicking it calls handleClear, which resets the Select's value.
+  renderEndAdornment = () => {
+    const { value, classes } = this.props;
+    return value ? (
+      <IconButton onClick={this.handleClear} className={classes.iconButton}>
+        <ClearIcon />
+      </IconButton>
+    ) : undefined;
   };
 
   render() {
@@ -68,18 +89,9 @@ class SelectInput extends Component {
               }}
               value={!!value ? JSON.stringify(value) : null}
               onChange={this._onChange}
-              // When there is a value, we pass a dummy div to effectively hide the default dropdown icon.
-              // This allows us to make room for the clear icon without having two icons visible at the same time.
-              IconComponent={value ? () => <div /> : undefined}
+              IconComponent={this.renderIconComponent()}
               disabled={disabled}
-              endAdornment={
-                // If there's a value, we render the clear icon. Clicking it calls handleClear, which resets the Select's value.
-                !!value ? (
-                  <IconButton onClick={this.handleClear} className={classes.iconButton}>
-                    <ClearIcon />
-                  </IconButton>
-                ) : undefined
-              }
+              endAdornment={this.renderEndAdornment()}
               displayEmpty
             >
               {placeholder && (

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -1,14 +1,25 @@
 import React, { Component, Fragment } from "react";
-import { withTheme, withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
-import { FormControl, InputLabel, Select, MenuItem } from "@material-ui/core";
+import _ from "lodash-uuid";
+
+import { FormControl, InputLabel, Select, MenuItem, IconButton } from "@material-ui/core";
+import { withTheme, withStyles } from "@material-ui/core/styles";
+
+import ClearIcon from "@material-ui/icons/Clear";
 import FormattedMessage from "../generics/FormattedMessage";
 import TextInput from "./TextInput";
-import _ from "lodash-uuid";
 
 const styles = (theme) => ({
   label: {
     color: theme.palette.primary.main,
+  },
+  formControl: {
+    position: "relative",
+  },
+  iconButton: {
+    position: "absolute",
+    right: 0,
+    padding: "8px",
   },
 });
 
@@ -17,6 +28,10 @@ class SelectInput extends Component {
     if (this.props.value !== e.target.value) {
       this.props.onChange(JSON.parse(e.target.value));
     }
+  };
+
+  handleClear = () => {
+    this.props.onChange("");
   };
 
   render() {
@@ -41,7 +56,7 @@ class SelectInput extends Component {
     return (
       <Fragment>
         {!readOnly && (
-          <FormControl required={required} fullWidth>
+          <FormControl required={required} fullWidth className={classes.formControl}>
             <InputLabel shrink={true} className={classes.label}>
               {strLabel ?? <FormattedMessage module={module} id={label} />}
             </InputLabel>
@@ -53,7 +68,18 @@ class SelectInput extends Component {
               }}
               value={!!value ? JSON.stringify(value) : null}
               onChange={this._onChange}
+              // When there is a value, we pass a dummy div to effectively hide the default dropdown icon.
+              // This allows us to make room for the clear icon without having two icons visible at the same time.
+              IconComponent={value ? () => <div /> : undefined}
               disabled={disabled}
+              endAdornment={
+                // If there's a value, we render the clear icon. Clicking it calls handleClear, which resets the Select's value.
+                !!value ? (
+                  <IconButton onClick={this.handleClear} className={classes.iconButton}>
+                    <ClearIcon />
+                  </IconButton>
+                ) : undefined
+              }
               displayEmpty
             >
               {placeholder && (


### PR DESCRIPTION
[OP-1726](https://openimis.atlassian.net/browse/OP-1726)

Changes:
- Integrate a "Clear" button into the SelectInput component.

Functionality details:
The "Clear" button remains hidden when no option is selected in the SelectInput component.
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/1cc8b617-f94c-440c-858b-4936e5e7d9c1)

Once an option is selected, the "Clear" button becomes visible, allowing the user to easily deselect the chosen option.
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/92f60084-f6d0-479d-be13-8aa815592ceb)


[OP-1726]: https://openimis.atlassian.net/browse/OP-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ