### PR TITLE
ONI-134: allow to extend table header

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import clsx from "clsx";
 import { injectIntl } from "react-intl";
 import _ from "lodash";

--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -231,7 +231,7 @@ class Table extends Component {
                 </Grid>
               </>
             ) : (
-              <Grid item xs={6}>
+              <Grid item xs={12}>
                 <Typography variant="h6">{header}</Typography>
               </Grid>
             )}

--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -185,6 +185,7 @@ class Table extends Component {
       fetching = null,
       error = null,
       showOrdinalNumber = false,
+      extendHeader,
     } = this.props;
     const { ordinalNumberFrom } = this.state;
     let localHeaders = [...(headers || [])];
@@ -219,11 +220,16 @@ class Table extends Component {
     return (
       <Box position="relative" overflow="auto">
         {header && (
-          <Fragment>
-            <Typography className={classes.tableTitle}>{header}</Typography>
-            <Divider />
-          </Fragment>
+          <Grid container alignItems="center" justify="space-between" className={classes.tableTitle}>
+            <Grid item xs={6}>
+              <Typography variant="h6">{header}</Typography>
+            </Grid>
+            <Grid item container direction="row" alignItems="center" justify="space-between" xs={6}>
+              {extendHeader && extendHeader()}
+            </Grid>
+          </Grid>
         )}
+        <Divider />
         <MUITable className={classes.table} size={size}>
           {!!localPreHeaders && localPreHeaders.length > 0 && (
             <TableHead>

--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -221,12 +221,20 @@ class Table extends Component {
       <Box position="relative" overflow="auto">
         {header && (
           <Grid container alignItems="center" justify="space-between" className={classes.tableTitle}>
-            <Grid item xs={6}>
-              <Typography variant="h6">{header}</Typography>
-            </Grid>
-            <Grid item container direction="row" alignItems="center" justify="space-between" xs={6}>
-              {extendHeader && extendHeader()}
-            </Grid>
+            {extendHeader ? (
+              <>
+                <Grid item xs={6}>
+                  <Typography variant="h6">{header}</Typography>
+                </Grid>
+                <Grid item container direction="row" alignItems="center" justify="space-between" xs={6}>
+                  {extendHeader && extendHeader()}
+                </Grid>
+              </>
+            ) : (
+              <Grid item xs={6}>
+                <Typography variant="h6">{header}</Typography>
+              </Grid>
+            )}
           </Grid>
         )}
         <Divider />


### PR DESCRIPTION
[ONI-134](https://openimis.atlassian.net/browse/ONI-134)

[RELATED PR](https://github.com/openimis/openimis-fe-claim_js/pull/171)

Changes:
- Add an _extendHeader_ prop to enhance the Table component's header with additional information provided by the parent component.

[ONI-134]: https://openimis.atlassian.net/browse/ONI-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ