### PR TITLE
OP-1747: create 401 403 500 error pages and extend right/error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 - `Help`: main menu entry for Help (link to manual)
 - `Logout`: main menu entry to logout
 - `KeepLegacyAlive`: component to be registered in core.Boot contribution to keep legacy openIMIS session alive while interacting with new openIMIS pages
+- `ErrorPage`: displays error messages with status, title, and optional logo. Includes navigation button to the homepage.
+- `PermissionCheck`: controls access to content based on user rights (403 error). Renders content if user has required rights, otherwise shows `ForbiddenPage`.
+- `ForbiddenPage`: shown when a user lacks permission to access a specific page or resource. Displays an access denied message.
+- `NotFoundPage`: appears when a user visits a non-existent route (404 error). Informs the user that the page is unavailable and suggests navigation option.
+- `InternalServerErrorPage`: displays a message for a 500 Internal Server Error, informing users of a server-side issue in the application.
 
 ## Generic Components (to be reused along business-focused components)
 
@@ -157,8 +162,8 @@ None
 - `secondCalendarFormattingLang`: formatting language for second calendar (when displayed as saved data, not in pickers), default: "en"
 - `redirectToCoreMISConfluenceUrl`: clicking on questionmark icon will take you to coreMIS confluence page, default openIMIS manual
 - `App.economicUnitConfig`:
-  In the specified configuration, when the parameter is set to __true__, it necessitates that users are associated with an Economic Unit. If a user lacks this association, a modal will be displayed to prompt them to establish it. Until the user is linked to a unit, their only authorized action is to log out. The default configuration is __false__.
-- `LogoutButton.showMPassProvider`:  when activated, routes the user to the saml logout page for secure session termination
+  In the specified configuration, when the parameter is set to **true**, it necessitates that users are associated with an Economic Unit. If a user lacks this association, a modal will be displayed to prompt them to establish it. Until the user is linked to a unit, their only authorized action is to log out. The default configuration is **false**.
+- `LogoutButton.showMPassProvider`: when activated, routes the user to the saml logout page for secure session termination
 - `LoginPage.showMPassProvider`: redirects users to the saml login page, facilitating access to mPass-protected resources
 - `secondCalendarType`: type of secondary calendar picker (if enabled), default "nepali"
 - `secondCalendarLocale`: locale for secondary calendar picker (if enabled), default "nepali_en"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -20,6 +20,8 @@ import SetPasswordPage from "../pages/SetPasswordPage";
 import { ErrorBoundary } from "@openimis/fe-core";
 import { onLogout } from "../helpers/utils";
 import { RIGHT_VIEW_EU_MODAL } from "../constants";
+import NotFoundPage from "./NotFoundPage";
+import PermissionCheck from "./PermissionCheck";
 
 export const ROUTER_CONTRIBUTION_KEY = "core.Router";
 export const UNAUTHENTICATED_ROUTER_CONTRIBUTION_KEY = "core.UnauthenticatedRouter";
@@ -51,6 +53,7 @@ const App = (props) => {
     modulesManager,
     basename = process.env.PUBLIC_URL,
     toggleCurrentCalendarType,
+    rights,
     ...others
   } = props;
 
@@ -101,7 +104,12 @@ const App = (props) => {
 
   useEffect(() => {
     const userHasModalRight = user?.rights ? user.rights.includes(RIGHT_VIEW_EU_MODAL) : false;
-    if (economicUnitConfig && userHasModalRight && auth.isAuthenticated && !localStorage.getItem(ECONOMIC_UNIT_STORAGE_KEY)) {
+    if (
+      economicUnitConfig &&
+      userHasModalRight &&
+      auth.isAuthenticated &&
+      !localStorage.getItem(ECONOMIC_UNIT_STORAGE_KEY)
+    ) {
       setEconomicUnitDialogOpen(true);
     }
 
@@ -172,12 +180,20 @@ const App = (props) => {
                           isSecondaryCalendar={isSecondaryCalendar}
                           setSecondaryCalendar={setSecondaryCalendar}
                         >
-                          <route.component modulesManager={modulesManager} {...props} {...others} />
+                          <PermissionCheck
+                            modulesManager={modulesManager}
+                            userRights={rights}
+                            requiredRights={route.requiredRights}
+                            {...others}
+                          >
+                            <route.component modulesManager={modulesManager} {...props} {...others} />
+                          </PermissionCheck>
                         </RequireAuth>
                       </ErrorBoundary>
                     )}
                   />
                 ))}
+                <Route render={() => <NotFoundPage {...others} />} />
               </Switch>
             </BrowserRouter>
           </div>
@@ -188,6 +204,7 @@ const App = (props) => {
 };
 
 const mapStateToProps = (state) => ({
+  rights: state.core.user?.i_user?.rights ?? [],
   user: state.core.user?.i_user,
   error: state.core.error,
   confirm: state.core.confirm,

--- a/src/components/ErrorPage.js
+++ b/src/components/ErrorPage.js
@@ -1,0 +1,71 @@
+import React from "react";
+
+import { Typography, Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
+
+import { useHistory } from "../helpers/history";
+
+const useStyles = makeStyles((theme) => ({
+  container: {
+    textAlign: "center",
+    height: "70vh",
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  logo: {
+    verticalAlign: "middle",
+    margin: theme.spacing(2),
+    maxHeight: theme.spacing(16),
+  },
+  title: {
+    margin: theme.spacing(2),
+    textTransform: "uppercase",
+    fontWeight: "bold",
+  },
+  description: {
+    margin: theme.spacing(2),
+    fontSize: "18px",
+  },
+  button: {
+    marginTop: theme.spacing(2),
+  },
+}));
+
+const ErrorPage = ({ status, title, description, logo, back }) => {
+  const history = useHistory();
+  const classes = useStyles();
+
+  return (
+    <div className={classes.container}>
+      {logo && <img className={classes.logo} src={logo} alt="Logo of openIMIS" />}
+      {status && (
+        <Typography variant="h1" className={classes.title}>
+          {status}
+        </Typography>
+      )}
+      <Typography variant="h2" className={classes.title}>
+        {title}
+      </Typography>
+      <Typography variant="body1" className={classes.description}>
+        {description}
+      </Typography>
+      {back && (
+        <Button
+          variant="contained"
+          color="primary"
+          size="large"
+          className={classes.button}
+          startIcon={<ArrowBackIcon />}
+          onClick={() => history.push("/")}
+        >
+          {back}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/src/components/ForbiddenPage.js
+++ b/src/components/ForbiddenPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+import ErrorPage from "./ErrorPage";
+import { useTranslations } from "../helpers/i18n";
+import { MODULE_NAME } from "../constants";
+
+const ForbiddenPage = (props) => {
+  const { formatMessage } = useTranslations(MODULE_NAME);
+
+  return (
+    <ErrorPage
+      status={401}
+      title={formatMessage("core.ForbiddenPage.title")}
+      description={formatMessage("core.ForbiddenPage.description")}
+      back={formatMessage("core.ErrorPage.back")}
+      {...props}
+    />
+  );
+};
+
+export default ForbiddenPage;

--- a/src/components/InternalServerErrorPage.js
+++ b/src/components/InternalServerErrorPage.js
@@ -1,0 +1,19 @@
+import React from "react";
+import ErrorPage from "./ErrorPage";
+import { useTranslations } from "../helpers/i18n";
+import { MODULE_NAME } from "../constants";
+
+const InternalServerErrorPage = (props) => {
+  const { formatMessage } = useTranslations(MODULE_NAME);
+
+  return (
+    <ErrorPage
+      status={500}
+      title={formatMessage("core.InternalServerErrorPage.title")}
+      description={formatMessage("core.InternalServerErrorPage.description")}
+      {...props}
+    />
+  );
+};
+
+export default InternalServerErrorPage;

--- a/src/components/NotFoundPage.js
+++ b/src/components/NotFoundPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { useTranslations } from "../helpers/i18n";
+import ErrorPage from "./ErrorPage";
+import { MODULE_NAME } from "../constants";
+
+const NotFoundPage = (props) => {
+  const { formatMessage } = useTranslations(MODULE_NAME);
+
+  return (
+    <ErrorPage
+      status={404}
+      title={formatMessage("core.NotFoundPage.title")}
+      description={formatMessage("core.NotFoundPage.description")}
+      back={formatMessage("core.ErrorPage.back")}
+      {...props}
+    />
+  );
+};
+
+export default NotFoundPage;

--- a/src/components/PermissionCheck.js
+++ b/src/components/PermissionCheck.js
@@ -18,7 +18,7 @@ const PermissionCheck = ({ userRights, requiredRights, children, ...props }) => 
       return false;
     }
 
-    return requiredRights.every((right) => userRights?.includes(right));
+    return requiredRights.some((right) => userRights?.includes(right));
   };
 
   return hasAccess() ? children : <ForbiddenPage {...props} />;

--- a/src/components/PermissionCheck.js
+++ b/src/components/PermissionCheck.js
@@ -1,0 +1,27 @@
+import React from "react";
+
+import ForbiddenPage from "./ForbiddenPage";
+
+const PermissionCheck = ({ userRights, requiredRights, children, ...props }) => {
+  const hasAccess = () => {
+    // NOTE: Currently, the route is accessible to all users if 'requiredRights' are not specified.
+    // This default behavior is subject to change in future iterations.
+
+    // TODO: Implement a more restrictive access policy where, by default, a route will require
+    // specific rights to be accessible. This will ensure tighter security.
+
+    if (!Array.isArray(requiredRights)) {
+      return true;
+    }
+
+    if (requiredRights.length === 0) {
+      return false;
+    }
+
+    return requiredRights.every((right) => userRights?.includes(right));
+  };
+
+  return hasAccess() ? children : <ForbiddenPage {...props} />;
+};
+
+export default PermissionCheck;

--- a/src/helpers/ErrorBoundary.js
+++ b/src/helpers/ErrorBoundary.js
@@ -1,4 +1,5 @@
 import React from "react";
+import InternalServerErrorPage from "../components/InternalServerErrorPage";
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -15,10 +16,12 @@ class ErrorBoundary extends React.Component {
     // Just log for now, could be reported elsewhere
     console.error(error, errorInfo);
   }
+  
   render() {
     if (this.state.hasError) {
-      return <h1>An error was not properly caught. Refer to console log.</h1>;
+      return <InternalServerErrorPage logo={this.props.children.props.logo} />;
     }
+
     return this.props.children;
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -121,5 +121,12 @@
   "core.exportColumnsDialog.confirmButton": "Ok",
   "core.exportColumnsDialog.cancelButton": "Cancel",
   "core.exportColumnsDialog.clearAllButton": "Clear All",
-  "core.exportColumnsDialog.title": "Select columns."
+  "core.exportColumnsDialog.title": "Select columns.",
+  "core.NotFoundPage.title": "Page not found",
+  "core.NotFoundPage.description": "The requested URL was not found on this server.",
+  "core.ErrorPage.back": "Move back to the home page",
+  "core.ForbiddenPage.title": "Access Denied",
+  "core.ForbiddenPage.description": "Sorry, you are not authorized to access this page.",
+  "core.InternalServerErrorPage.title": "Internal Server Error",
+  "core.InternalServerErrorPage.description": "The server encountered an internal error or misconfiguration and was unable to complete your request."
 }


### PR DESCRIPTION
[OP-1747](https://openimis.atlassian.net/browse/OP-1747)

Changes:
- Develop and integrate a variety of error pages (401, 404, 500).
- Enhance the "core.Router" contribution by introducing a new property, **requiredRights**. This feature will manage access permissions to resources, ensuring that unauthorized access attempts are met with an error message and a subsequent redirection to an appropriate error page.
- Update Lokalise keys.

Summary:
1. Access is automatically allowed if **requiredRights** is undefined.
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/b85902de-7f0d-499b-b8d9-ee0d96a0c5b8)
2. Access is universally denied and an error page displayed if **requiredRights** is an empty array.
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/4b0e7209-3994-40cb-bb15-cc5be64e7701)
3. When **requiredRights** is specified with necessary rights, access is conditionally granted based on permission validation.
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/0893b78d-9950-438c-b4ec-1b74c32b1967)

![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/da9c2e36-48f8-41f9-a443-69905f8fb645)


[OP-1747]: https://openimis.atlassian.net/browse/OP-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ