### PR TITLE
OP-1759: allow value to be empty

### DIFF
--- a/src/components/inputs/Autocomplete.js
+++ b/src/components/inputs/Autocomplete.js
@@ -12,7 +12,7 @@ const styles = (theme) => ({
   },
 });
 
-const defaultGetOptionSelected = (option, v) => option.id === v.id;
+const defaultGetOptionSelected = (option, v) => option.id === v?.id;
 
 const Autocomplete = (props) => {
   const {


### PR DESCRIPTION
[OP-1759](https://openimis.atlassian.net/browse/OP-1759)

[RELATED PR](https://github.com/openimis/openimis-fe-claim_js/pull/175)

Changes:
- Allow Autocomplete value to be empty.

[OP-1759]: https://openimis.atlassian.net/browse/OP-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ