### PR TITLE
OP-1790: add possibility to hide cell if formatter is null

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -334,6 +334,9 @@ class Table extends Component {
                   {localItemFormatters &&
                     localItemFormatters.map((f, fidx) => {
                       if (colSpans.length > fidx && !colSpans[fidx]) return null;
+                      // NOTE: The 'f' function can explicitly be set to null, enabling the option to omit 
+                      // a column  and suppress its display under specific conditions.
+                      if (f === null) return null;
                       return (
                         <TableCell
                           colSpan={colSpans.length > fidx ? colSpans[fidx] : 1}


### PR DESCRIPTION
[OP-1790](https://openimis.atlassian.net/browse/OP-1790)

[RELATED PR](https://github.com/openimis/openimis-fe-policy_js/pull/84)

Changes:
- If formatter function is null, return null (do not return a cell).

[OP-1790]: https://openimis.atlassian.net/browse/OP-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ