### PR TITLE
OP-1817: hide validity dates if historical data not requested

### DIFF
--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -172,14 +172,14 @@ class Roles extends Component {
 
   fetch = (params) => this.props.fetchRoles(params);
 
-  headers = () => {
+  headers = (filters) => {
     const { rights } = this.props;
     let result = [
       "roleManagement.roleName",
       "roleManagement.isSystem",
       "roleManagement.isBlocked",
-      "roleManagement.dateValidFrom",
-      "roleManagement.dateValidTo",
+      filters?.showHistory?.value ? "roleManagement.dateValidFrom" : null,
+      filters?.showHistory?.value ? "roleManagement.dateValidTo" : null,
     ];
     [RIGHT_ROLE_UPDATE, RIGHT_ROLE_DUPLICATE, RIGHT_ROLE_DELETE].forEach((right) => {
       if (rights.includes(right)) {
@@ -189,7 +189,7 @@ class Roles extends Component {
     return result;
   };
 
-  itemFormatters = () => {
+  itemFormatters = (filters) => {
     const { intl, rights, modulesManager, language } = this.props;
     const result = [
       (role) =>
@@ -202,8 +202,14 @@ class Roles extends Component {
           : role.altLanguage,
       (role) => (role.isSystem !== null ? <Checkbox checked={!!role.isSystem} disabled /> : ""),
       (role) => (role.isBlocked !== null ? <Checkbox checked={role.isBlocked} disabled /> : ""),
-      (role) => (!!role.validityFrom ? formatDateFromISO(modulesManager, intl, role.validityFrom) : ""),
-      (role) => (!!role.validityTo ? formatDateFromISO(modulesManager, intl, role.validityTo) : ""),
+      (role) =>
+        filters?.showHistory?.value && role.validityFrom
+          ? formatDateFromISO(modulesManager, intl, role.validityFrom)
+          : null,
+      (role) =>
+        filters?.showHistory?.value && role.validityTo
+          ? formatDateFromISO(modulesManager, intl, role.validityTo)
+          : null,
     ];
     if (rights.includes(RIGHT_ROLE_SEARCH) || rights.includes(RIGHT_ROLE_UPDATE)) {
       result.push((role) =>
@@ -262,12 +268,12 @@ class Roles extends Component {
     this.setState({ confirmedAction }, confirm);
   };
 
-  sorts = () => [
+  sorts = (filters) => [
     ["name", true],
     ["isSystem", true],
     ["isBlocked", true],
-    ["validityFrom", true],
-    ["validityTo", true],
+    filters?.showHistory?.value ? ["validityFrom", true] : null,
+    filters?.showHistory?.value ? ["validityTo", true] : null,
   ];
 
   isRowDisabled = (_, role) =>


### PR DESCRIPTION
OP-1817

Changes:

- Roles: Show or hide "Validity From" and "Validity To" columns based on the showHistory filter.