### PR TITLE
OP-1829: add possibility to disable delete button

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -186,6 +186,7 @@ class Table extends Component {
       error = null,
       showOrdinalNumber = false,
       extendHeader,
+      disableDeleteOnEmptyRow = false,
     } = this.props;
     const { ordinalNumberFrom } = this.state;
     let localHeaders = [...(headers || [])];
@@ -206,11 +207,14 @@ class Table extends Component {
     if (!!onDelete) {
       if (localPreHeaders) localPreHeaders.push("");
       localHeaders.push("");
-      localItemFormatters.push((i, idx) => (
-        <IconButton onClick={(e) => onDelete(idx)}>
-          <DeleteIcon />
-        </IconButton>
-      ));
+      localItemFormatters.push((i, idx) => {
+        const isEmpty = disableDeleteOnEmptyRow ? _.isEmpty(i) : false;
+        return (
+          <IconButton disabled={isEmpty} onClick={(e) => onDelete(idx)}>
+            <DeleteIcon />
+          </IconButton>
+        );
+      });
     }
 
     const rowsPerPage = pageSize || rowsPerPageOptions[0];


### PR DESCRIPTION
[OP-1829](https://openimis.atlassian.net/browse/OP-1829)

[RELATED](https://github.com/openimis/openimis-fe-claim_js/pull/180)

Changes:
- If _disableDeleteOnEmptyRow_ is true, disable the delete button on empty row.

[OP-1829]: https://openimis.atlassian.net/browse/OP-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ