### PR TITLE
OP-1830: enable changing min value of amount input - default 0

### DIFF
--- a/src/components/inputs/AmountInput.js
+++ b/src/components/inputs/AmountInput.js
@@ -1,20 +1,24 @@
-import React, { Component } from "react";
+import React from "react";
 import { injectIntl } from "react-intl";
 import { InputAdornment } from "@material-ui/core";
 import NumberInput from "./NumberInput";
 import { useModulesManager } from "../../helpers/modules";
 
-const AmountInput = ({ intl, ...props }) => {
+const AmountInput = ({ intl, inputMinValue = 0, ...props }) => {
   const modulesManager = useModulesManager();
   const position = modulesManager.getConf("fe-core", "AmountInput.currencyPosition", "start");
+
   if (!["start", "end"].includes(position)) {
     throw new Error(`Position ${position} is not accepted. Only 'start' and 'end' are valid options.`);
   }
+
   const extraProps = {
     [`${position}Adornment`]: (
       <InputAdornment position={position}>{intl.formatMessage({ id: "currency" })}</InputAdornment>
     ),
+    min: inputMinValue,
   };
+
   return <NumberInput {...props} {...extraProps} />;
 };
 


### PR DESCRIPTION
[OP-1830](https://openimis.atlassian.net/browse/OP-1830)

[RELATED](https://github.com/openimis/openimis-fe-claim_js/pull/181)

Changes:
- Set min value to 0 by default.
- Added possibility to change the min value.
- If value is set to negative, there is an error: 
![image](https://github.com/openimis/openimis-fe-core_js/assets/109145288/db60b1d3-997c-464c-8f24-0a130b0104e5)


[OP-1830]: https://openimis.atlassian.net/browse/OP-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ