### PR TITLE
hotfix: do not fetch instantly on filters change

### DIFF
--- a/src/components/generics/Searcher.js
+++ b/src/components/generics/Searcher.js
@@ -268,7 +268,7 @@ class Searcher extends Component {
         filters[filter.id] = { value: filter.value, filter: filter.filter };
       }
     });
-    this.setState({ filters }, (e) => this.applyFilters());
+    this.setState({ filters });
   };
 
   _cacheAndApply = () => {


### PR DESCRIPTION
Hotfix: 
- Disable fetching on every filters change. Now user has to change a filter and click on the Search button.


![Peek 2024-03-08 15-02](https://github.com/openimis/openimis-fe-core_js/assets/109145288/4c2273e4-d890-484b-8a88-2f677ddc1c1c)
