### PR TITLE
OP-1825: add filter on role by authority

### DIFF
--- a/src/components/RoleRightsPanel.js
+++ b/src/components/RoleRightsPanel.js
@@ -22,6 +22,7 @@ import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import SearchIcon from "@material-ui/icons/Search";
 import DoubleArrowIcon from "@material-ui/icons/DoubleArrow";
+import { formatRoleLabel } from "../helpers/role-label-formatter";
 
 const styles = (theme) => ({
   item: theme.paper.item,
@@ -50,12 +51,6 @@ const styles = (theme) => ({
     gap: "5px",
   },
 });
-
-const RIGHT_NAME_WORDS_SEPARATOR = "_";
-const RIGHT_NAME_OMITTED_WORDS = ["gql", "mutation", "perms"];
-const QUERY_STRING = "query";
-const SEARCH_STRING = "search";
-const WHITESPACE = " ";
 
 class RoleRightsPanel extends FormPanel {
   constructor(props) {
@@ -93,12 +88,7 @@ class RoleRightsPanel extends FormPanel {
     const translatedMessage = formatMessage(this.props.intl, null, translationId);
     const translationFound = translatedMessage !== translationId;
     if (!translationFound) {
-      const rightNameWords = permsName
-        .split(RIGHT_NAME_WORDS_SEPARATOR)
-        .filter((word) => !RIGHT_NAME_OMITTED_WORDS.includes(word));
-      const rightNameLabel = rightNameWords.join(WHITESPACE).replace(QUERY_STRING, SEARCH_STRING);
-      const moduleNameLabel = moduleName.split(RIGHT_NAME_WORDS_SEPARATOR).join(WHITESPACE);
-      return `${moduleNameLabel} | ${rightNameLabel}`;
+      return formatRoleLabel(moduleName, permsName);
     }
     return translatedMessage;
   };
@@ -145,9 +135,7 @@ class RoleRightsPanel extends FormPanel {
     if (filterValue) {
       const filteredPerms = this.filterPermissions(false);
 
-      const restPerms = roleRights.filter(
-        (right) => !filteredPerms.some((filteredRight) => filteredRight === right),
-      );
+      const restPerms = roleRights.filter((right) => !filteredPerms.some((filteredRight) => filteredRight === right));
 
       onEditedChanged({ roleRights: restPerms, ...restState });
       return;

--- a/src/helpers/role-label-formatter.js
+++ b/src/helpers/role-label-formatter.js
@@ -3,10 +3,12 @@ const RIGHT_NAME_OMITTED_WORDS = ["gql", "mutation", "perms"];
 const QUERY_STRING = "query";
 const SEARCH_STRING = "search";
 const WHITESPACE = " ";
-const WORD_REGEX = /^(\w|\s\w)/g;
 
 const capitalizeFirstLetter = (string) => {
-  return string.toLowerCase().replace(WORD_REGEX, (letter) => letter.toUpperCase());
+  return string
+    .split(WHITESPACE)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(WHITESPACE);
 };
 
 export const formatRoleLabel = (moduleName = "", permName = "") => {

--- a/src/helpers/role-label-formatter.js
+++ b/src/helpers/role-label-formatter.js
@@ -1,0 +1,23 @@
+const RIGHT_NAME_WORDS_SEPARATOR = "_";
+const RIGHT_NAME_OMITTED_WORDS = ["gql", "mutation", "perms"];
+const QUERY_STRING = "query";
+const SEARCH_STRING = "search";
+const WHITESPACE = " ";
+
+const capitalizeFirstLetter = (string) => {
+  return string.toLowerCase().replace(/^\w|\s\w/g, (letter) => letter.toUpperCase());
+};
+
+export const formatRoleLabel = (moduleName = "", permName = "") => {
+  const rightNameWords = permName
+    .split(RIGHT_NAME_WORDS_SEPARATOR)
+    .filter((word) => !RIGHT_NAME_OMITTED_WORDS.includes(word));
+
+  const rightNameLabel = rightNameWords
+    .map(capitalizeFirstLetter)
+    .join(WHITESPACE)
+    .replace(QUERY_STRING, SEARCH_STRING);
+  const moduleNameLabel = moduleName.split(RIGHT_NAME_WORDS_SEPARATOR).map(capitalizeFirstLetter).join(WHITESPACE);
+
+  return `${moduleNameLabel} | ${rightNameLabel}`;
+};

--- a/src/helpers/role-label-formatter.js
+++ b/src/helpers/role-label-formatter.js
@@ -3,7 +3,7 @@ const RIGHT_NAME_OMITTED_WORDS = ["gql", "mutation", "perms"];
 const QUERY_STRING = "query";
 const SEARCH_STRING = "search";
 const WHITESPACE = " ";
-const WORD_REGEX = /^\w|\s\w/g;
+const WORD_REGEX = /^(\w|\s\w)/g;
 
 const capitalizeFirstLetter = (string) => {
   return string.toLowerCase().replace(WORD_REGEX, (letter) => letter.toUpperCase());

--- a/src/helpers/role-label-formatter.js
+++ b/src/helpers/role-label-formatter.js
@@ -3,9 +3,10 @@ const RIGHT_NAME_OMITTED_WORDS = ["gql", "mutation", "perms"];
 const QUERY_STRING = "query";
 const SEARCH_STRING = "search";
 const WHITESPACE = " ";
+const WORD_REGEX = /^\w|\s\w/g;
 
 const capitalizeFirstLetter = (string) => {
-  return string.toLowerCase().replace(/^\w|\s\w/g, (letter) => letter.toUpperCase());
+  return string.toLowerCase().replace(WORD_REGEX, (letter) => letter.toUpperCase());
 };
 
 export const formatRoleLabel = (moduleName = "", permName = "") => {

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ import CustomFilterTypeStatusPicker from "./pickers/CustomFilterTypeStatusPicker
 import YearPicker from "./pickers/YearPicker";
 import MonthPicker from "./pickers/MonthPicker";
 import LanguagePicker from "./pickers/LanguagePicker";
+import AuthorityPicker from "./pickers/AuthorityPicker";
 import Helmet from "./helpers/Helmet";
 import AccountBox from "@material-ui/icons/AccountBox";
 import Roles from "./pages/Roles";
@@ -176,6 +177,7 @@ const DEFAULT_CONFIG = {
     { key: "core.YearPicker", ref: YearPicker },
     { key: "core.MonthPicker", ref: MonthPicker },
     { key: "core.LanguagePicker", ref: LanguagePicker },
+    { key: "core.AuthorityPicker", ref: AuthorityPicker },
     { key: "core.route.role", ref: ROUTE_ROLE },
   ],
   "core.Boot": [KeepLegacyAlive, RefreshAuthToken],

--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -22,6 +22,7 @@ import {
   historyPush,
   coreConfirm,
   journalize,
+  PublishedComponent,
   SelectInput,
   clearCurrentPaginationPage,
 } from "@openimis/fe-core";
@@ -84,6 +85,16 @@ class RawRoleFilter extends Component {
     ]);
   };
 
+  onChangeRoleRight = (key, value) => {
+    this.props.onChangeFilters([
+      {
+        id: key,
+        value,
+        filter: `${key}: ${value?.permsValue}`,
+      },
+    ]);
+  };
+
   booleanOptions = () => {
     const options = [null, "true", "false"];
     return [
@@ -122,6 +133,13 @@ class RawRoleFilter extends Component {
             options={this.booleanOptions()}
             value={this._filterValue("isBlocked")}
             onChange={(v) => this._onChangeFilter("isBlocked", v)}
+          />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <PublishedComponent
+            pubRef="core.AuthorityPicker"
+            value={this._filterValue("roleRight")}
+            onChange={(roleRight) => this.onChangeRoleRight("roleRight", roleRight)}
           />
         </Grid>
         <Grid item xs={3} className={classes.item}>

--- a/src/pickers/AuthorityPicker.js
+++ b/src/pickers/AuthorityPicker.js
@@ -4,6 +4,9 @@ import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } fro
 import { MODULE_NAME } from "../constants";
 import { formatRoleLabel } from "../helpers/role-label-formatter";
 
+const WHITESPACE_REGEX = /\s/g;
+const UNDERSCORE_REGEX = /_/g;
+
 const AuthorityPicker = ({
   onChange,
   readOnly,
@@ -39,12 +42,12 @@ const AuthorityPicker = ({
   const filteredPerms = useMemo(() => {
     if (!data) return [];
 
-    const concatenatedSearchString = searchString.replace(/\s/g, "").toLowerCase();
+    const concatenatedSearchString = searchString.replace(WHITESPACE_REGEX, "").toLowerCase();
 
     return data.modulesPermissions.modulePermsList.flatMap((module) =>
       module.permissions
         .filter((perm) => {
-          const concatenatedPermName = (module.moduleName + perm.permsName).replace(/_/g, "").toLowerCase();
+          const concatenatedPermName = (module.moduleName + perm.permsName).replace(UNDERSCORE_REGEX, "").toLowerCase();
           return concatenatedPermName.includes(concatenatedSearchString);
         })
         .map((perm) => ({

--- a/src/pickers/AuthorityPicker.js
+++ b/src/pickers/AuthorityPicker.js
@@ -1,0 +1,82 @@
+import React, { useState, useMemo } from "react";
+
+import { useModulesManager, useTranslations, Autocomplete, useGraphqlQuery } from "@openimis/fe-core";
+import { MODULE_NAME } from "../constants";
+import { formatRoleLabel } from "../helpers/role-label-formatter";
+
+const AuthorityPicker = ({
+  onChange,
+  readOnly,
+  required,
+  withLabel = true,
+  withPlaceholder,
+  value,
+  label,
+  filterOptions,
+  filterSelectedOptions,
+  placeholder,
+}) => {
+  const modulesManager = useModulesManager();
+  const [searchString, setSearchString] = useState("");
+  const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
+
+  const { isLoading, data, error } = useGraphqlQuery(
+    `
+    query AuthorityPicker {
+        modulesPermissions  {
+            modulePermsList {
+                moduleName
+                permissions {
+                    permsName
+                    permsValue
+                }
+            }
+        }
+    }
+    `,
+  );
+
+  const filteredPerms = useMemo(() => {
+    if (!data) return [];
+
+    const concatenatedSearchString = searchString.replace(/\s/g, "").toLowerCase();
+
+    return data.modulesPermissions.modulePermsList.flatMap((module) =>
+      module.permissions
+        .filter((perm) => {
+          const concatenatedPermName = (module.moduleName + perm.permsName).replace(/_/g, "").toLowerCase();
+          return concatenatedPermName.includes(concatenatedSearchString);
+        })
+        .map((perm) => ({
+          id: perm.permsValue,
+          module: module.moduleName,
+          ...perm,
+        })),
+    );
+  }, [data, searchString]);
+
+  const formatLabel = (perm) => formatRoleLabel(perm.module, perm.permsName);
+
+  return (
+    <Autocomplete
+      options={filteredPerms}
+      getOptionLabel={formatLabel}
+      onChange={(option) => onChange(option)}
+      required={required}
+      placeholder={placeholder ?? formatMessage("core.AuthorityPicker.placeholder")}
+      label={label ?? formatMessage("core.AuthorityPicker.label")}
+      withLabel={withLabel}
+      withPlaceholder={withPlaceholder}
+      readOnly={readOnly}
+      isLoading={isLoading}
+      error={error}
+      value={value}
+      filterOptions={filterOptions}
+      filterSelectedOptions={filterSelectedOptions}
+      setCurrentString={setSearchString}
+      onInputChange={() => {}}
+    />
+  );
+};
+
+export default AuthorityPicker;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -133,5 +133,7 @@
   "core.InternalServerErrorPage.description": "The server encountered an internal error or misconfiguration and was unable to complete your request.",
   "core.tooltip.logout": "Log out",
   "core.tooltip.help": "Documentation",
-  "core.NeDateFormatter.dateOutOfRange": "DATE_OUT_OF_RANGE"
+  "core.NeDateFormatter.dateOutOfRange": "DATE_OUT_OF_RANGE",
+  "core.AuthorityPicker.label": "Authority",
+  "core.AuthorityPicker.placeholder": "Search..."
 }


### PR DESCRIPTION
[OP-1825](https://openimis.atlassian.net/browse/OP-1825)

[BE PR](https://github.com/openimis/openimis-be-core_py/pull/277)

Changes:
- Integrate the role right label format.
- Add Authority picker to extend filters.

[OP-1825]: https://openimis.atlassian.net/browse/OP-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ