### PR TITLE
CQI-156: added fatal error page for rate limit

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,7 +7,7 @@ import { withTheme, withStyles } from "@material-ui/core/styles";
 import withModulesManager, { ModulesManagerProvider } from "../helpers/modules";
 import Helmet from "../helpers/Helmet";
 import RequireAuth from "./RequireAuth";
-import FatalError from "./generics/FatalError";
+import FatalErrorPage from "./generics/FatalError";
 import { clearConfirm, toggleCurrentCalendarType } from "../actions";
 import AlertDialog from "./dialogs/AlertDialog";
 import ConfirmDialog from "./dialogs/ConfirmDialog";
@@ -29,7 +29,6 @@ export const UNAUTHENTICATED_ROUTER_CONTRIBUTION_KEY = "core.UnauthenticatedRout
 export const APP_BOOT_CONTRIBUTION_KEY = "core.Boot";
 export const TRANSLATION_CONTRIBUTION_KEY = "translations";
 export const ECONOMIC_UNIT_DIALOG_CONTRIBUTION_KEY = "policyholder.EconomicUnitDialog";
-
 const ECONOMIC_UNIT_STORAGE_KEY = "userEconomicUnit";
 
 const styles = () => ({
@@ -125,7 +124,11 @@ const App = (props) => {
   }, [isSecondaryCalendar]);
 
   if (error) {
-    return <FatalError error={error} />;
+    return (
+      <IntlProvider locale={locale} messages={allMessages}>
+        <FatalErrorPage error={error} />
+      </IntlProvider>
+    );
   }
 
   if (!auth.isInitialized) return null;

--- a/src/components/generics/FatalError.js
+++ b/src/components/generics/FatalError.js
@@ -1,43 +1,30 @@
-import React, { Fragment } from "react";
-import withStyles from "@material-ui/core/styles/withStyles";
-import { Typography, Divider } from "@material-ui/core";
+import React from "react";
+import ErrorPage from "../ErrorPage";
+import { useTranslations } from "../../helpers/i18n";
+import { MODULE_NAME } from "../../constants";
 
-const styles = (theme) => ({
-  fatal: {
-    position: "absolute",
-    top: "50%",
-    left: "50%",
-    transform: "translate(-50%,-50%)",
-    borderStyle: "solid",
-    borderWidth: "thin",
-    borderColor: theme.palette.error.secondary,
-    padding: theme.spacing(2),
-  },
-  fatalHeader: {
-    color: theme.palette.error.main,
-  },
-  fatalDetail: {
-    color: theme.palette.error.main,
-  },
-});
+const FatalErrorPage = (props) => {
+  const { formatMessage } = useTranslations(MODULE_NAME);
+  const { error } = props;
 
-function FatalError(props) {
-  const { classes, error } = props;
+  let title, description;
+
+  if (error && error.code === 429) {
+    title = formatMessage("core.FatalError.RateLimitExceeded.title");
+    description = formatMessage("core.FatalError.RateLimitExceeded.description");
+  } else {
+    title = formatMessage("core.FatalError.GenericError.title");
+    description = (error && error.message) || formatMessage("core.FatalError.GenericError.description");
+  }
+
   return (
-    <div className={classes.fatal}>
-      <Typography variant="h6" className={classes.fatalHeader}>
-        {error.code}: {error.message}
-      </Typography>
-      {!!error.detail && (
-        <Fragment>
-          <Divider />
-          <Typography variant="body1" className={classes.fatalCode}>
-            {error.detail}
-          </Typography>
-        </Fragment>
-      )}
-    </div>
+    <ErrorPage
+      status={error?.code || "Unknown"}
+      title={title}
+      description={description}
+      {...props}
+    />
   );
-}
+};
 
-export default withStyles(styles)(FatalError);
+export default FatalErrorPage;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -135,5 +135,9 @@
   "core.tooltip.help": "Documentation",
   "core.NeDateFormatter.dateOutOfRange": "DATE_OUT_OF_RANGE",
   "core.AuthorityPicker.label": "Authority",
-  "core.AuthorityPicker.placeholder": "Search..."
+  "core.AuthorityPicker.placeholder": "Search...",
+  "core.FatalError.RateLimitExceeded.description": "You have exceeded the number of allowed requests. Please try again later.",
+  "core.FatalError.RateLimitExceeded.title": "Rate Limit Exceeded",
+  "core.FatalError.GenericError.description": "Error",
+  "core.FatalError.GenericError.title": "An unexpected error occurred"
 }


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/CQI-156

Changes:
- fatal error page is now using ErrorPage component
- there is different message based on the status.code returned

How was it tested?
1. For rate limit error it worked as intended

Note:
Fatal error page should not include return button for now, it would create an issue where user is blocked because he tried to spam application so he won't be able to use the button if he reached the limit.