### PR TITLE
Added configuration for fe-core : shouldFetchInitially for searcher component in core

### DIFF
--- a/src/components/generics/Searcher.js
+++ b/src/components/generics/Searcher.js
@@ -196,7 +196,10 @@ class Searcher extends Component {
     clearAll: 0,
     menuAnchor: null,
   };
-
+  constructor(props) {
+    super(props);
+    this.fetchEnabled = props.modulesManager.getConf("fe-core", "shouldFetchInitially", true);
+  }
   componentDidMount() {
     const cacheKey = this._getCacheKey();
     var filters = this.props.filtersCache[cacheKey] || this.props.defaultFilters || {};
@@ -206,7 +209,11 @@ class Searcher extends Component {
         pageSize: props.defaultPageSize || 10,
         orderBy: props.defaultOrderBy,
       }),
-      (e) => this.applyFilters()
+      (e) => {
+        if (this.fetchEnabled) {
+          this.applyFilters();
+        }
+      }
     );
   }
 


### PR DESCRIPTION

The searcher will not fetch the data if  "shouldFetchInitially"  : false  (set to false), default it is true.

Location for adding configuration : core_moduleConfiguration => fe-core

