### PR TITLE
OM-270: add limitTags prop to the autocomplete

### DIFF
--- a/src/components/inputs/Autocomplete.js
+++ b/src/components/inputs/Autocomplete.js
@@ -39,6 +39,7 @@ const Autocomplete = (props) => {
     multiple = false,
     renderInput,
     noOptionsText,
+    limitTags,
   } = props;
   const modulesManager = useModulesManager();
   const minCharLookup = modulesManager.getConf("fe-admin", "usersMinCharLookup", 2);
@@ -90,6 +91,7 @@ const Autocomplete = (props) => {
       open={open}
       onOpen={() => setOpen(true)}
       onClose={() => setOpen(false)}
+      limitTags={limitTags ? limitTags : Infinity}
       autoComplete
       value={value}
       getOptionLabel={getOptionLabel ?? ((option) => option.label)}


### PR DESCRIPTION
[OM-270](https://openimis.atlassian.net/browse/OM-270)

Changes:
- Add possibility to pass limitTags property to the Autocomplete component. If not passed, there is no limit.

[OM-270]: https://openimis.atlassian.net/browse/OM-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ