### PR TITLE
fixed language picker not calling the GraphQL endpoint to fetchLanguages issue

### DIFF
--- a/src/pickers/LanguagePicker.js
+++ b/src/pickers/LanguagePicker.js
@@ -7,7 +7,7 @@ import { fetchLanguages } from "../actions";
 
 class LanguagePicker extends Component {
   componentDidMount() {
-    if (!this.props.languages) {
+    if (!this.props.languages?.length) {
       // prevent loading multiple times the cache when component is several times on a page
       setTimeout(() => {
         !this.props.fetching && !this.props.fetched && this.props.fetchLanguages();


### PR DESCRIPTION
The issue was in checking if the language list is already fetched or not. To check if there are any elements in list we should check the length. This is fixed now and the language drop-down is working as expected. 

<img width="1125" alt="Screenshot 2024-08-28 at 7 51 09 PM" src="https://github.com/user-attachments/assets/90b9e49a-d076-4baf-b76b-8d8725338c00">
