### PR TITLE
OM-342: add toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ None
 
 ## Configurations Options
 - `core.PublicPage`: This contributions point serves as the Public Page for the OpenIMIS App. To enable its use, it must be exposed as a **core.PublicPage** contribution point. Additionally, the database configuration variable **App.enablePublicPage** must be set to `true`.
+- `showJournalSidebar`: This determines whether to render the Journal sidebar or not. __IMPORTANT__:  The Journal provides crucial information about the state of mutations, including whether they succeeded or failed. If you choose to hide it, you must ensure the user is informed of the mutation outcome - consider using toast notifications. **This configuration only hides the Journal. It does not automatically add toast notifications out of the box.**.
 - `datePicker`: the concrete date picker to publish as `core.DatePicker` component ("ad"= Gregorian DatePicker, "ne"= Nepali calendar date picker )
 - `useDynPermalinks`: use ?dyn=<Base64-URL> when opening in new tab (prevent sending client-side routes to server while) (Default: false)
 - `core.JournalDrawer.pollInterval`: poll interval (in ms) to check for mutation status once submitted (Default: 2000)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ It is dedicated to be deployed as a module of [openimis-fe_js](https://github.co
 
 ## Helpers
 
+### Contexts
+
+- `ToastContext`: This context provides toast notification functionality within the application. It enables you to easily display success, error, warning, or informational messages as toast notifications.
+__To use it__, you need to import `useToast` from `@openimis/fe-core` and use one of the provided functions (e.g., `showSuccess`, `showError`, `showWarning`, `showInfo`) to trigger different types of toast notifications.
+
 ### redux actions helpers
 
 - `journalize`: helper to trigger the `CORE_MUTATION_ADD` action (which register a mutation in the journal)

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -24,6 +24,7 @@ import NotFoundPage from "./NotFoundPage";
 import PermissionCheck from "./PermissionCheck";
 import PublishedComponent from "./generics/PublishedComponent";
 import PublicPageMiddleware from "./PublicPageMiddleware";
+import { ToastProvider } from "../helpers/ToastContext";
 
 export const ROUTER_CONTRIBUTION_KEY = "core.Router";
 export const UNAUTHENTICATED_ROUTER_CONTRIBUTION_KEY = "core.UnauthenticatedRouter";
@@ -139,76 +140,75 @@ const App = (props) => {
       <CssBaseline />
       <ModulesManagerProvider value={modulesManager}>
         <IntlProvider locale={locale} messages={allMessages}>
-          <AlertDialog />
-          <ConfirmDialog confirm={confirm} onConfirm={clearConfirm} />
-          {economicUnitConfig ? (
-            <Contributions
-              contributionKey={ECONOMIC_UNIT_DIALOG_CONTRIBUTION_KEY}
-              open={economicUnitDialogOpen}
-              setEconomicUnitDialogOpen={setEconomicUnitDialogOpen}
-              onLogout={onLogout}
-            />
-          ) : null}
-          <PublishedComponent
-            pubRef="grievanceSocialProtection.GrievanceConfigurationDialog"
-            rights={rights}
-          />
-          <div className="App">
-            {auth.isAuthenticated && <Contributions contributionKey={APP_BOOT_CONTRIBUTION_KEY} />}
-            <BrowserRouter basename={basename}>
-              <Switch>
-                <Route
-                  exact
-                  path="/"
-                  render={() => <PublicPageMiddleware isAuthenticated={auth.isAuthenticated} {...others} />}
-                />
-                <Route path={"/login"} render={() => <LoginPage {...others} />} />
-                <Route path={"/forgot_password"} render={() => <ForgotPasswordPage {...others} />} />
-                <Route path={"/set_password"} render={() => <SetPasswordPage {...others} />} />
-                {unauthenticatedRoutes.map((route) => (
+          <ToastProvider>
+            <AlertDialog />
+            <ConfirmDialog confirm={confirm} onConfirm={clearConfirm} />
+            {economicUnitConfig ? (
+              <Contributions
+                contributionKey={ECONOMIC_UNIT_DIALOG_CONTRIBUTION_KEY}
+                open={economicUnitDialogOpen}
+                setEconomicUnitDialogOpen={setEconomicUnitDialogOpen}
+                onLogout={onLogout}
+              />
+            ) : null}
+            <PublishedComponent pubRef="grievanceSocialProtection.GrievanceConfigurationDialog" rights={rights} />
+            <div className="App">
+              {auth.isAuthenticated && <Contributions contributionKey={APP_BOOT_CONTRIBUTION_KEY} />}
+              <BrowserRouter basename={basename}>
+                <Switch>
                   <Route
                     exact
-                    key={route.path}
-                    path={"/" + route.path}
-                    render={(props) => (
-                      <ErrorBoundary>
-                        <route.component modulesManager={modulesManager} {...props} {...others} />
-                      </ErrorBoundary>
-                    )}
+                    path="/"
+                    render={() => <PublicPageMiddleware isAuthenticated={auth.isAuthenticated} {...others} />}
                   />
-                ))}
-                {routes.map((route) => (
-                  <Route
-                    exact
-                    key={route.path}
-                    path={"/" + route.path}
-                    render={(props) => (
-                      <ErrorBoundary>
-                        <RequireAuth
-                          {...props}
-                          {...others}
-                          redirectTo={"/login"}
-                          onEconomicDialogOpen={() => setEconomicUnitDialogOpen(true)}
-                          isSecondaryCalendar={isSecondaryCalendar}
-                          setSecondaryCalendar={setSecondaryCalendar}
-                        >
-                          <PermissionCheck
-                            modulesManager={modulesManager}
-                            userRights={rights}
-                            requiredRights={route.requiredRights}
+                  <Route path={"/login"} render={() => <LoginPage {...others} />} />
+                  <Route path={"/forgot_password"} render={() => <ForgotPasswordPage {...others} />} />
+                  <Route path={"/set_password"} render={() => <SetPasswordPage {...others} />} />
+                  {unauthenticatedRoutes.map((route) => (
+                    <Route
+                      exact
+                      key={route.path}
+                      path={"/" + route.path}
+                      render={(props) => (
+                        <ErrorBoundary>
+                          <route.component modulesManager={modulesManager} {...props} {...others} />
+                        </ErrorBoundary>
+                      )}
+                    />
+                  ))}
+                  {routes.map((route) => (
+                    <Route
+                      exact
+                      key={route.path}
+                      path={"/" + route.path}
+                      render={(props) => (
+                        <ErrorBoundary>
+                          <RequireAuth
+                            {...props}
                             {...others}
+                            redirectTo={"/login"}
+                            onEconomicDialogOpen={() => setEconomicUnitDialogOpen(true)}
+                            isSecondaryCalendar={isSecondaryCalendar}
+                            setSecondaryCalendar={setSecondaryCalendar}
                           >
-                            <route.component modulesManager={modulesManager} {...props} {...others} />
-                          </PermissionCheck>
-                        </RequireAuth>
-                      </ErrorBoundary>
-                    )}
-                  />
-                ))}
-                <Route render={() => <NotFoundPage {...others} />} />
-              </Switch>
-            </BrowserRouter>
-          </div>
+                            <PermissionCheck
+                              modulesManager={modulesManager}
+                              userRights={rights}
+                              requiredRights={route.requiredRights}
+                              {...others}
+                            >
+                              <route.component modulesManager={modulesManager} {...props} {...others} />
+                            </PermissionCheck>
+                          </RequireAuth>
+                        </ErrorBoundary>
+                      )}
+                    />
+                  ))}
+                  <Route render={() => <NotFoundPage {...others} />} />
+                </Switch>
+              </BrowserRouter>
+            </div>
+          </ToastProvider>
         </IntlProvider>
       </ModulesManagerProvider>
     </>

--- a/src/components/RequireAuth.js
+++ b/src/components/RequireAuth.js
@@ -224,6 +224,7 @@ const RequireAuth = (props) => {
     false,
   );
   const isWorker = modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
+  const showJournalSidebar = modulesManager.getConf("fe-core", "showJournalSidebar", DEFAULT.SHOW_JOURNAL_SIDEBAR);
 
   const isAppBarMenu = useMemo(() => theme.menu.variant.toUpperCase() === "APPBAR", [theme.menu.variant]);
 
@@ -288,7 +289,7 @@ const RequireAuth = (props) => {
         position="fixed"
         className={clsx({
           [classes.appBarShift]: isOpen && theme.breakpoints.up("md"),
-          [classes.appBar]: !isWorker,
+          [classes.appBar]: showJournalSidebar,
         })}
       >
         <Toolbar>
@@ -367,12 +368,12 @@ const RequireAuth = (props) => {
           </nav>
         </ClickAwayListener>
       )}
-      {!isWorker && <JournalDrawer open={isDrawerOpen} handleDrawer={setDrawerOpen.toggle} />}
+      {showJournalSidebar && <JournalDrawer open={isDrawerOpen} handleDrawer={setDrawerOpen.toggle} />}
       <div className={classes.toolbar} />
       <main
         className={clsx({
           [classes.jrnlContentShift]: isDrawerOpen,
-          [classes.content]: !isWorker,
+          [classes.content]: showJournalSidebar,
         })}
       >
         {children}

--- a/src/constants.js
+++ b/src/constants.js
@@ -129,6 +129,7 @@ export const ENTER_KEY = "Enter";
 export const DEFAULT = {
   IS_WORKER: false,
   ENABLE_PUBLIC_PAGE: false,
+  SHOW_JOURNAL_SIDEBAR: true,
 }
 
 export const EXPORT_FILE_FORMATS = {

--- a/src/helpers/ToastContext.js
+++ b/src/helpers/ToastContext.js
@@ -1,0 +1,70 @@
+import React, { createContext, useState, useContext, useCallback, useMemo } from "react";
+import { Typography, Snackbar } from "@material-ui/core";
+import MuiAlert from "@material-ui/lab/Alert";
+
+const CONFIG = {
+  AUTOHIDE_DURATION: 5000,
+  ANCHOR_ORIGIN: { vertical: "bottom", horizontal: "left" },
+  SEVERITY_LEVELS: {
+    SUCCESS: "success",
+    ERROR: "error",
+    WARNING: "warning",
+    INFO: "info",
+  },
+};
+
+function Alert(props) {
+  return <MuiAlert elevation={4} variant="filled" {...props} />;
+}
+
+const ToastContext = createContext();
+
+export function ToastProvider({ children }) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [severity, setSeverity] = useState(CONFIG.SEVERITY_LEVELS.INFO);
+
+  const showToast = useCallback((message, severity) => {
+    setMessage(message);
+    setSeverity(severity);
+    setOpen(true);
+  }, []);
+
+  const hideToast = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      showSuccess: (message) => showToast(message, CONFIG.SEVERITY_LEVELS.SUCCESS),
+      showError: (message) => showToast(message, CONFIG.SEVERITY_LEVELS.ERROR),
+      showWarning: (message) => showToast(message, CONFIG.SEVERITY_LEVELS.WARNING),
+      showInfo: (message) => showToast(message, CONFIG.SEVERITY_LEVELS.INFO),
+    }),
+    [showToast],
+  );
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <Snackbar
+        open={open}
+        anchorOrigin={CONFIG.ANCHOR_ORIGIN}
+        autoHideDuration={CONFIG.AUTOHIDE_DURATION}
+        onClose={hideToast}
+      >
+        <Alert onClose={hideToast} severity={severity} style={{ maxWidth: 500, minWidth: 300 }}>
+          <Typography variant="body1"> {message} </Typography>
+        </Alert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ import withHistory, {
   Redirect,
   NavLink,
 } from "./helpers/history";
+import { useToast } from "./helpers/ToastContext";
 import { validatePassword } from "./helpers/passwordValidator";
 import { passwordGenerator } from "./helpers/passwordGenerator"
 import { createFieldsBasedOnJSON, renderInputComponent } from "./helpers/json-handler-utils";
@@ -325,4 +326,5 @@ export {
   SearcherActionButton,
   passwordGenerator,
   EXPORT_FILE_FORMATS,
+  useToast,
 };


### PR DESCRIPTION
[OM-342](https://openimis.atlassian.net/browse/OM-342)

Changes:
- Add toasts.
- To use toast, you need to use `useToast` hook, which allows you to render 4 types of toasts: info, warning, error, success.
- Add `showJournalSidebar` to determine whether to render the Journal or not.

[OM-342]: https://openimis.atlassian.net/browse/OM-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ