### PR TITLE
OM-336: create info button component

### DIFF
--- a/src/components/generics/InfoButton.js
+++ b/src/components/generics/InfoButton.js
@@ -1,0 +1,100 @@
+import React, { useState, useCallback } from "react";
+import clsx from "clsx";
+
+import { makeStyles } from "@material-ui/styles";
+import { IconButton, Popover, Typography, Tooltip } from "@material-ui/core";
+import InfoIcon from "@material-ui/icons/Info";
+import { useTranslations } from "../../helpers/i18n";
+import { MODULE_NAME } from "../../constants";
+
+const useStyles = makeStyles((theme) => ({
+  popoverContent: {
+    padding: theme.spacing(1),
+  },
+  iconSmall: {
+    fontSize: 16,
+  },
+  iconMedium: {
+    fontSize: 24,
+  },
+  iconLarge: {
+    fontSize: 32,
+  },
+  maxWidthSmall: {
+    maxWidth: 300,
+  },
+  maxWidthMedium: {
+    maxWidth: 450,
+  },
+  maxWidthLarge: {
+    maxWidth: 600,
+  },
+}));
+
+export default function InfoButton({
+  iconSize = "medium",
+  iconColor = "primary",
+  iconButtonSize = "medium",
+  maxWidth = "medium",
+  content = "",
+  anchorOrigin = {
+    vertical: "bottom",
+    horizontal: "center",
+  },
+  transformOrigin = {
+    vertical: "top",
+    horizontal: "right",
+  },
+}) {
+  const classes = useStyles();
+  const { formatMessage } = useTranslations(MODULE_NAME);
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleClick = useCallback((event) => {
+    setAnchorEl(event.currentTarget);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  const open = Boolean(anchorEl);
+  const id = open ? "info-popover" : undefined;
+
+  return (
+    <>
+      <Tooltip title={formatMessage("InfoButton.tooltip")}>
+        <IconButton size={iconButtonSize} onClick={handleClick} aria-describedby={id}>
+          <InfoIcon
+            color={iconColor}
+            className={clsx({
+              [classes.iconSmall]: iconSize === "small",
+              [classes.iconMedium]: iconSize === "medium",
+              [classes.iconLarge]: iconSize === "large",
+            })}
+          />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
+      >
+        <Typography
+          variant="body2"
+          className={clsx({
+            [classes.popoverContent]: true,
+            [classes.maxWidthSmall]: maxWidth === "small",
+            [classes.maxWidthMedium]: maxWidth === "medium",
+            [classes.maxWidthLarge]: maxWidth === "large",
+          })}
+        >
+          {content}
+        </Typography>
+      </Popover>
+    </>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ import RefreshAuthToken from "./components/RefreshAuthToken";
 import UserActivityReport from "./reports/UserActivityReport";
 import RegistersStatusReport from "./reports/RegistersStatusReport";
 import SearcherActionButton from "./components/generics/SearcherActionButton";
+import InfoButton from "./components/generics/InfoButton";
 
 const ROUTE_ROLES = "roles";
 const ROUTE_ROLE = "roles/role";
@@ -327,4 +328,5 @@ export {
   passwordGenerator,
   EXPORT_FILE_FORMATS,
   useToast,
+  InfoButton,
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -152,5 +152,6 @@
   "core.LanguageQuickPicker.dialog.cancel": "Cancel",
   "core.LoginPage.backButton": "Back",
   "core.LoginPage.loginCaption": "Authentication by",
-  "core.LoginPage.howToUse": "User guide"
+  "core.LoginPage.howToUse": "User guide",
+  "core.InfoButton.tooltip": "More Information"
 }


### PR DESCRIPTION
[OM-336](https://openimis.atlassian.net/browse/OM-336)

Changes:
- Add `InfoButton` component. It allows to display some content as a popover (few sizes supported etc).
![image](https://github.com/user-attachments/assets/e053a556-6ca9-488a-bdff-9171b222299e)


[OM-336]: https://openimis.atlassian.net/browse/OM-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ