### PR TITLE
OM-364:add possibility to enable better visibility of disabled inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,4 +175,5 @@ None
 - `LogoutButton.showMPassProvider`: when activated, routes the user to the saml logout page for secure session termination
 - `LoginPage.showMPassProvider`: redirects users to the saml login page, facilitating access to mPass-protected resources
 - `secondCalendarType`: type of secondary calendar picker (if enabled), default "nepali"
-- `secondCalendarLocale`: locale for secondary calendar picker (if enabled), default "nepali_en"
+- `secondCalendarLocale`: locale for secondary calendar picker (if enabled), default "nepali_en",
+- `Input.disabledVisibilityBoost`: This setting enhances the visibility of disabled input fields (e.g., text/number inputs, date pickers). When set to __true__, the label color changes to `#181716`, and the input value color to `#5E5B50`. The default is __false__.

--- a/src/components/inputs/TextInput.js
+++ b/src/components/inputs/TextInput.js
@@ -1,8 +1,11 @@
 import React, { Component } from "react";
+import clsx from "clsx";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
 import { TextField } from "@material-ui/core";
 import { formatMessage } from "../../helpers/i18n";
+import { DEFAULT } from "../../constants";
+import withModulesManager from "../../helpers/modules";
 
 const styles = (theme) => ({
   label: {
@@ -10,21 +13,41 @@ const styles = (theme) => ({
   },
   // NOTE: This is used to hide the increment/decrement arrows from the number input
   numberInput: {
-    '& input[type=number]': {
-        '-moz-appearance': 'textfield'
+    "& input[type=number]": {
+      "-moz-appearance": "textfield",
     },
-    '& input[type=number]::-webkit-outer-spin-button': {
-        '-webkit-appearance': 'none',
-        margin: 0
+    "& input[type=number]::-webkit-outer-spin-button": {
+      "-webkit-appearance": "none",
+      margin: 0,
     },
-    '& input[type=number]::-webkit-inner-spin-button': {
-        '-webkit-appearance': 'none',
-        margin: 0
+    "& input[type=number]::-webkit-inner-spin-button": {
+      "-webkit-appearance": "none",
+      margin: 0,
+    },
+  },
+  disabledStateVisibilityBoost: {
+    "& .Mui-disabled": {
+      color: '#5E5B50',
+    },
+    "& .MuiInput-underline:before": {
+      borderBottom: `1px dotted #5E5B50`,
+    },
+    "& .MuiFormLabel-root.Mui-disabled": {
+      color: "#181716",
     }
   },
 });
 
 class TextInput extends Component {
+  constructor(props) {
+    super(props);
+    this.disabledVisibilityBoost = props.modulesManager.getConf(
+      "fe-core",
+      "Input.disabledVisibilityBoost",
+      DEFAULT.DISABLED_VISIBILITY_BOOST,
+    );
+  }
+
   state = {
     value: "",
   };
@@ -49,7 +72,7 @@ class TextInput extends Component {
     }
   }
   _onChange = (e) => {
-    let {value} = e.target;
+    let { value } = e.target;
     if (this.props.formatInput) {
       value = this.props.formatInput(value);
     }
@@ -76,7 +99,10 @@ class TextInput extends Component {
     return (
       <TextField
         {...others}
-        className={classes.numberInput}
+        className={clsx({
+          [classes.numberInput]: true,
+          [classes.disabledStateVisibilityBoost]: this.disabledVisibilityBoost && readOnly,
+        })}
         fullWidth
         disabled={readOnly}
         label={!!label && formatMessage(intl, module, label)}
@@ -94,4 +120,4 @@ class TextInput extends Component {
   }
 }
 
-export default injectIntl(withTheme(withStyles(styles)(TextInput)));
+export default withModulesManager(injectIntl(withTheme(withStyles(styles)(TextInput))));

--- a/src/constants.js
+++ b/src/constants.js
@@ -132,6 +132,7 @@ export const DEFAULT = {
   IS_WORKER: false,
   ENABLE_PUBLIC_PAGE: false,
   SHOW_JOURNAL_SIDEBAR: true,
+  DISABLED_VISIBILITY_BOOST: false,
 }
 
 export const EXPORT_FILE_FORMATS = {

--- a/src/pickers/DatePicker.js
+++ b/src/pickers/DatePicker.js
@@ -1,12 +1,15 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import clsx from "clsx";
 import moment from "moment";
-import { withTheme, withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
+
+import { withTheme, withStyles } from "@material-ui/core/styles";
 import { FormControl } from "@material-ui/core";
 import { DatePicker as MUIDatePicker } from "@material-ui/pickers";
 import { formatMessage, toISODate } from "../helpers/i18n";
 import { withModulesManager, withHistory } from "@openimis/fe-core";
+import { DEFAULT } from "../constants";
 
 import DatePicker from "react-multi-date-picker";
 import nepali from "../calendars/NepalCalendar";
@@ -20,6 +23,17 @@ const styles = (theme) => ({
   label: {
     color: theme.palette.primary.main,
   },
+  disabledStateVisibilityBoost: {
+    "& .MuiFormLabel-root.Mui-disabled": {
+      color: "#181716",
+    },
+    "& .MuiInputBase-input.Mui-disabled": {
+      color: "#5E5B50",
+    },
+    "& .MuiInput-underline:before": {
+      borderBottom: `1px dotted #5E5B50`,
+    },
+  },
 });
 
 function fromISODate(s) {
@@ -28,6 +42,15 @@ function fromISODate(s) {
 }
 
 class openIMISDatePicker extends Component {
+  constructor(props) {
+    super(props);
+    this.disabledVisibilityBoost = props.modulesManager.getConf(
+      "fe-core",
+      "Input.disabledVisibilityBoost",
+      DEFAULT.DISABLED_VISIBILITY_BOOST,
+    );
+  }
+
   state = {
     value: null,
   };
@@ -143,6 +166,9 @@ class openIMISDatePicker extends Component {
             format={format}
             disabled={readOnly}
             required={required}
+            className={clsx({
+              [classes.disabledStateVisibilityBoost]: this.disabledVisibilityBoost && readOnly,
+            })}
             clearable
             value={this.state.value}
             InputLabelProps={{


### PR DESCRIPTION
[OM-364](https://openimis.atlassian.net/browse/OM-364)

Changes:
- Add `Input.disabledVisibilityBoost` configuration. This setting improves the visibility of disabled input fields (text/number inputs, date pickers). 
![image](https://github.com/user-attachments/assets/21932712-31be-4de2-b6fb-a2c27442c534)


[OM-364]: https://openimis.atlassian.net/browse/OM-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ