### PR TITLE
OM-363: add translations to next/prev button

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -418,6 +418,8 @@ class Table extends Component {
                   rowsPerPageOptions={rowsPerPageOptions}
                   onRowsPerPageChange={(e) => onChangeRowsPerPage(e.target.value)}
                   onPageChange={onChangePage}
+                  nextIconButtonText={formatMessage(intl, "core", "Table.nextPage")}
+                  backIconButtonText={formatMessage(intl, "core", "Table.previousPage")}
                 />
               </TableRow>
             </TableFooter>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -151,5 +151,7 @@
   "core.LoginPage.backButton": "Back",
   "core.LoginPage.loginCaption": "Authentication by",
   "core.LoginPage.howToUse": "User guide",
-  "core.InfoButton.tooltip": "More Information"
+  "core.InfoButton.tooltip": "More Information",
+  "core.Table.nextPage": "Next page",
+  "core.Table.previousPage": "Previous page"
 }


### PR DESCRIPTION
[OM-363](https://openimis.atlassian.net/browse/OM-363)

Changes:
- Allow to translate the tooltip text of next/prev button in Table component.

[OM-363]: https://openimis.atlassian.net/browse/OM-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ