### PR TITLE
OSB-14: added icons for custom and existing menus - based on config

### DIFF
--- a/src/components/MainMenuBar.js
+++ b/src/components/MainMenuBar.js
@@ -102,7 +102,6 @@ const MainMenuBar = ({ children = null, contributionKey, reverse = false, menuVa
   const rights = useSelector((state) => state.core?.user?.i_user?.rights || []);
   const components = useMemo(() => {
     const components = getMenus(modulesManager, contributionKey, rights, menuVariant);
-    console.log('components', components);
     if (reverse) {
       components.reverse();
     }

--- a/src/components/generics/MainMenuContribution.js
+++ b/src/components/generics/MainMenuContribution.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from "react";
+import * as Icons from "@material-ui/icons";
 import PropTypes from "prop-types";
 import MuiAccordion from "@material-ui/core/Accordion";
 import MuiAccordionDetails from "@material-ui/core/AccordionDetails";
@@ -174,6 +175,10 @@ class MainMenuContribution extends Component {
     _historyPush(modulesManager, history, route);
   }
 
+  getIconComponent = (iconName) => {
+    return Icons[iconName]
+  };
+
   appBarMenu = (entries) => {
     return (
       <Fragment>
@@ -240,7 +245,7 @@ class MainMenuContribution extends Component {
                     this.redirect(entry.route);
                   }}
                 >
-                  <ListItemIcon>{entry.icon}</ListItemIcon>
+                  {entry.icon && <ListItemIcon>{entry.icon}</ListItemIcon>}
                   <ListItemText primary={entry.text}/>
                 </ListItem>
                 {entry.withDivider && (

--- a/src/components/generics/MainMenuContribution.js
+++ b/src/components/generics/MainMenuContribution.js
@@ -98,10 +98,19 @@ const AccordionDetails = withStyles((theme) => ({
   },
 }))(MuiAccordionDetails);
 
+const getIconComponent = (iconName) => {
+  const IconComponent = Icons[iconName];
+  if (IconComponent) {
+    return <IconComponent />;
+  }
+  return null;
+};
+
 function fetchSubmenuConfig(modulesManager, allEntries, entries, menuId, rights) {
   const menuConfig = modulesManager.getConf("fe-core", "menus", []);
   const isMenuConfigEmpty = !(menuConfig?.length);
   const submenuMapping = {};
+  const menuIcons = {}; 
   const copyOfEntries = entries;
 
   if (!isMenuConfigEmpty) {
@@ -110,14 +119,21 @@ function fetchSubmenuConfig(modulesManager, allEntries, entries, menuId, rights)
       .forEach(menu => {
         (menu.submenus || []).forEach(submenu => {
           submenuMapping[submenu.id] = submenu.position;
+          if (submenu.icon) {
+            menuIcons[submenu.id] = submenu.icon;
+          }
         });
       });
 
     const updatedEntries = allEntries
-      .map(entry => ({
-        ...entry,
-        position: submenuMapping[entry.id] || null,
-      }))
+      .map(entry => {
+        const customIcon = menuIcons[entry.id];
+        return {
+          ...entry,
+          position: submenuMapping[entry.id] || null,
+          icon: customIcon ? getIconComponent(customIcon) : entry.icon,
+        };
+      })
       .filter(entry => entry.position !== null)
       .sort((a, b) => a.position - b.position);
 
@@ -174,10 +190,6 @@ class MainMenuContribution extends Component {
     const { modulesManager, history } = this.props;
     _historyPush(modulesManager, history, route);
   }
-
-  getIconComponent = (iconName) => {
-    return Icons[iconName]
-  };
 
   appBarMenu = (entries) => {
     return (


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OSB-14

If no icon provided - the default one from code level is displayed. 

Examples:
![Screenshot from 2025-03-20 16-47-41](https://github.com/user-attachments/assets/856332c9-dd41-4d19-800b-fc74204491dc)

![Screenshot from 2025-03-20 16-45-50](https://github.com/user-attachments/assets/6ed5fce8-ed4d-40d6-9dc3-4e678c571351)

![Screenshot from 2025-03-20 14-34-31](https://github.com/user-attachments/assets/5b6ecc05-726e-4724-abe2-c18d39f2d1fe)

![Screenshot from 2025-03-20 16-42-37](https://github.com/user-attachments/assets/26dc3f46-2ddb-412c-98e0-f1d5ce4a5998)

