### PR TITLE
fix: Omit CSRF token from login mutation

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -288,7 +288,7 @@ export function login(credentials) {
       try {
         const response = await dispatch(
           graphqlMutation(mutation, credentials, ["CORE_AUTH_LOGIN_REQ", "CORE_AUTH_LOGIN_RESP", "CORE_AUTH_ERR"], {}, false, {
-            "X-CSRFToken": csrfToken
+           
           }),
         );
         if (response.payload?.errors?.length > 0) {


### PR DESCRIPTION

### What Changed

The \`graphqlMutation\` for login was attempting to include a CSRF token. However, at the login stage, the token has not yet been fetched from the backend, causing the request to fail.

### Why It Matters

This commit removes the CSRF token from the login mutation to ensure the initial authentication can complete successfully.

### Next Steps

The CSRF token will be fetched and used for subsequent authenticated requests."
