### PR TITLE
set a general formatting for prices OP-2567

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Whenever the **individual** global schema changes (you add or remove a filter fi
 - `formatMessage`: provide the translation of a module-prefixed key (fall back on openimis-fe_js/translations/ref.json)
 - `formatMessageWithValues`: provide the translation of a module-prefixed key, for messages with vairable parts
 - `formatAmount`: format an amount as a string
+    with config
+    - `fe-core`, "thousandSeparator", "fr"
+    - `fe-core`, "numberOfDecimals", 2
+    - `fe-core`, "pricesAreDecimal", true
+    the config thousandSeparator set the locale use by Intl.NumberFormat (e.g. "en") if you don't want formatting, set default value ""
+    
 - `formatDateFromISO`: parse ISO date into (local) datetime
 
   Note: depends on the selected calendar (Gregorian vs. Nepali)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Whenever the **individual** global schema changes (you add or remove a filter fi
 - `formatMessageWithValues`: provide the translation of a module-prefixed key, for messages with vairable parts
 - `formatAmount`: format an amount as a string
     with config
-    - `fe-core`, "thousandSeparator", "fr"
+    - `fe-core`, "thousandSeparator", "en"
     - `fe-core`, "numberOfDecimals", 2
     - `fe-core`, "pricesAreDecimal", true
     the config thousandSeparator set the locale use by Intl.NumberFormat (e.g. "en") if you don't want formatting, set default value ""

--- a/src/components/inputs/FormattedNumberInput.js
+++ b/src/components/inputs/FormattedNumberInput.js
@@ -7,9 +7,6 @@ import { withModulesManager } from "@openimis/fe-core";
 class FormattedNumberInput extends Component {
   constructor(props) {
     super(props);
-
-    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
-
     this.state = {
       isEdited: false,
       rawValue: props.value != null
@@ -19,7 +16,6 @@ class FormattedNumberInput extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    // Si la valeur du serveur change et que l’utilisateur n’édite pas, on reformate
     if (prevProps.value !== this.props.value && !this.state.isEdited) {
       this.setState({
         rawValue: this.props.value != null
@@ -31,9 +27,9 @@ class FormattedNumberInput extends Component {
 
   formatNumber = (value, intl) => {
     if (value == null || isNaN(value)) return "";
-    return new Intl.NumberFormat(intl, {
-      minimumFractionDigits: this.pricesAreDecimal ? 2 : 0,
-      maximumFractionDigits: this.pricesAreDecimal ? 2 : 0,
+    return new Intl.NumberFormat(this.props.thousandSeparator, {
+      minimumFractionDigits: this.props.pricesAreDecimal ? this.props.numberOfDecimals : 0,
+      maximumFractionDigits: this.props.pricesAreDecimal ? this.props.numberOfDecimals : 0,
     }).format(value);
   };
 
@@ -87,6 +83,9 @@ class FormattedNumberInput extends Component {
       max = null,
       error,
       allowDecimals = true,
+      thousandSeparator,
+      numberOfDecimals,
+      pricesAreDecimal,
       ...others
     } = this.props;
 

--- a/src/components/inputs/FormattedNumberInput.js
+++ b/src/components/inputs/FormattedNumberInput.js
@@ -1,0 +1,124 @@
+import React, { Component } from "react";
+import TextInput from "./TextInput";
+import { injectIntl } from "react-intl";
+import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
+import { withModulesManager } from "@openimis/fe-core";
+
+class FormattedNumberInput extends Component {
+  constructor(props) {
+    super(props);
+
+    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
+
+    this.state = {
+      isEdited: false,
+      rawValue: props.value != null
+        ? this.formatNumber(props.value, props.intl)
+        : "",
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    // Si la valeur du serveur change et que l’utilisateur n’édite pas, on reformate
+    if (prevProps.value !== this.props.value && !this.state.isEdited) {
+      this.setState({
+        rawValue: this.props.value != null
+          ? this.formatNumber(this.props.value, this.props.intl)
+          : "",
+      });
+    }
+  }
+
+  formatNumber = (value, intl) => {
+    if (value == null || isNaN(value)) return "";
+    return new Intl.NumberFormat(intl, {
+      minimumFractionDigits: this.pricesAreDecimal ? 2 : 0,
+      maximumFractionDigits: this.pricesAreDecimal ? 2 : 0,
+    }).format(value);
+  };
+
+  handleKeyPress = (event) => {
+    const { allowDecimals = true } = this.props;
+    if (event.key === "." && !allowDecimals) {
+      event.preventDefault();
+    }
+  };  
+
+  handleChange = (val) => {
+    const raw = val;
+    this.setState({ rawValue: raw });
+
+    const normalized = raw.replace(/\s/g, "").replace(",", ".");
+    const value = parseFloat(normalized);
+    this.props.onChange(isNaN(value) ? undefined : value);
+  };
+
+  handleBlur = () => {
+    const { intl, displayNa } = this.props;
+    const { rawValue } = this.state;
+
+    this.setState({ isEdited: false });
+
+    if ((rawValue === "" || isNaN(Number(rawValue))) && displayNa) {
+      this.setState({
+        rawValue: formatMessage(intl, this.props.module, "core.NumberInput.notApplicable"),
+      });
+      return;
+    }
+
+    const number = parseFloat(rawValue.replace(/\s/g, "").replace(",", "."));
+    if (isNaN(number)) {
+      this.setState({ rawValue: "" });
+      return;
+    }
+
+    this.setState({ rawValue: this.formatNumber(number, intl) });
+  };
+
+  handleFocus = () => {
+    this.setState({ isEdited: true });
+  };
+
+  render() {
+    const {
+      intl,
+      module = "core",
+      min = null,
+      max = null,
+      error,
+      allowDecimals = true,
+      ...others
+    } = this.props;
+
+    let inputProps = {
+      ...this.props.inputProps,
+      type: "text",
+      onKeyPress: this.handleKeyPress,
+    };
+
+    let err = error;
+
+    const numericValue = parseFloat(this.state.rawValue.replace(/\s/g, "").replace(",", "."));
+    if (min != null && numericValue < min) {
+      err = formatMessageWithValues(intl, module, "validation.minValue", { value: numericValue, min });
+    }
+    if (max != null && numericValue > max) {
+      err = formatMessageWithValues(intl, module, "validation.maxValue", { value: numericValue, max });
+    }
+
+    return (
+      <TextInput
+        {...others}
+        module={module}
+        value={this.state.rawValue}
+        error={err}
+        inputProps={inputProps}
+        onChange={this.handleChange}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
+      />
+    );
+  }
+}
+
+export default withModulesManager(injectIntl(FormattedNumberInput));

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -7,76 +7,47 @@ import { withModulesManager } from "@openimis/fe-core";
 class NumberInput extends Component {
   constructor(props) {
     super(props);
-
-    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
-
     this.state = {
       isEdited: false,
-      rawValue: props.value != null
-        ? this.formatNumber(props.value, props.intl)
-        : "",
     };
+    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
   }
-
-  componentDidUpdate(prevProps) {
-    // Si la valeur du serveur change et que l’utilisateur n’édite pas, on reformate
-    if (prevProps.value !== this.props.value && !this.state.isEdited) {
-      this.setState({
-        rawValue: this.props.value != null
-          ? this.formatNumber(this.props.value, this.props.intl)
-          : "",
-      });
-    }
-  }
-
-  formatNumber = (value, intl) => {
-    if (value == null || isNaN(value)) return "";
-    return new Intl.NumberFormat(intl, {
-      minimumFractionDigits: this.pricesAreDecimal ? 2 : 0,
-      maximumFractionDigits: this.pricesAreDecimal ? 2 : 0,
-    }).format(value);
-  };
 
   handleKeyPress = (event) => {
     const { allowDecimals = true } = this.props;
+
     if (event.key === "." && !allowDecimals) {
       event.preventDefault();
     }
-  };  
-
-  handleChange = (val) => {
-    const raw = val;
-    this.setState({ rawValue: raw });
-
-    const normalized = raw.replace(/\s/g, "").replace(",", ".");
-    const value = parseFloat(normalized);
-    this.props.onChange(isNaN(value) ? undefined : value);
   };
 
-  handleBlur = () => {
-    const { intl, displayNa } = this.props;
-    const { rawValue } = this.state;
+  formatInput = (value, displayZero, displayNa, decimal) => {
+    if (!value) {
+      if (displayNa && !this.state.isEdited) {
+        return formatMessage(this.props.intl, this.props.module, "core.NumberInput.notApplicable");
+      }
+      return displayZero && value === 0 ? "0" : "";
+    }
 
+    const numericValue = Number(value);
+
+    if (isNaN(numericValue)) return "";
+
+    if (decimal) {
+      if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 2) {
+        return parseFloat(value).toFixed(2);
+      }
+      return value;
+    }
+
+    return parseFloat(value);
+  };
+
+  handleNaBlur = () => {
+    if ((isNaN(this.props.value) || this.props.value === "") && this.state.isEdited) {
+      this.props.onChange(undefined);
+    }
     this.setState({ isEdited: false });
-
-    if ((rawValue === "" || isNaN(Number(rawValue))) && displayNa) {
-      this.setState({
-        rawValue: formatMessage(intl, this.props.module, "core.NumberInput.notApplicable"),
-      });
-      return;
-    }
-
-    const number = parseFloat(rawValue.replace(/\s/g, "").replace(",", "."));
-    if (isNaN(number)) {
-      this.setState({ rawValue: "" });
-      return;
-    }
-
-    this.setState({ rawValue: this.formatNumber(number, intl) });
-  };
-
-  handleFocus = () => {
-    this.setState({ isEdited: true });
   };
 
   render() {
@@ -85,37 +56,43 @@ class NumberInput extends Component {
       module = "core",
       min = null,
       max = null,
+      value,
       error,
-      allowDecimals = true,
+      displayZero = false,
+      displayNa = false,
+      allowDecimals = this.pricesAreDecimal,
       ...others
     } = this.props;
-
-    let inputProps = {
-      ...this.props.inputProps,
-      type: "text",
-      onKeyPress: this.handleKeyPress,
-    };
-
+    let inputProps = { ...this.props.inputProps, type: "number", onKeyPress: this.handleKeyPress };
     let err = error;
 
-    const numericValue = parseFloat(this.state.rawValue.replace(/\s/g, "").replace(",", "."));
-    if (min != null && numericValue < min) {
-      err = formatMessageWithValues(intl, module, "validation.minValue", { value: numericValue, min });
+    if (min !== null) {
+      inputProps.min = min;
+      if (value < min)
+        err = formatMessageWithValues(intl, module, "validation.minValue", {
+          value,
+          min,
+        });
     }
-    if (max != null && numericValue > max) {
-      err = formatMessageWithValues(intl, module, "validation.maxValue", { value: numericValue, max });
+    if (max !== null) {
+      inputProps.max = max;
+      if (value > max)
+        err = formatMessageWithValues(intl, module, "validation.maxValue", {
+          value,
+          max,
+        });
     }
 
     return (
       <TextInput
         {...others}
         module={module}
-        value={this.state.rawValue}
+        value={value}
         error={err}
         inputProps={inputProps}
-        onChange={this.handleChange}
-        onBlur={this.handleBlur}
-        onFocus={this.handleFocus}
+        formatInput={(v) => this.formatInput(v, displayZero, displayNa, allowDecimals)}
+        onFocus={() => this.setState({ isEdited: true })}
+        onBlur={() => this.handleNaBlur()}
       />
     );
   }

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -2,50 +2,81 @@ import React, { Component } from "react";
 import TextInput from "./TextInput";
 import { injectIntl } from "react-intl";
 import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
+import { withModulesManager } from "@openimis/fe-core";
 
 class NumberInput extends Component {
   constructor(props) {
     super(props);
+
+    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
+
     this.state = {
       isEdited: false,
+      rawValue: props.value != null
+        ? this.formatNumber(props.value, props.intl)
+        : "",
     };
   }
 
+  componentDidUpdate(prevProps) {
+    // Si la valeur du serveur change et que l’utilisateur n’édite pas, on reformate
+    if (prevProps.value !== this.props.value && !this.state.isEdited) {
+      this.setState({
+        rawValue: this.props.value != null
+          ? this.formatNumber(this.props.value, this.props.intl)
+          : "",
+      });
+    }
+  }
+
+  formatNumber = (value, intl) => {
+    if (value == null || isNaN(value)) return "";
+    return new Intl.NumberFormat(intl, {
+      minimumFractionDigits: this.pricesAreDecimal ? 2 : 0,
+      maximumFractionDigits: this.pricesAreDecimal ? 2 : 0,
+    }).format(value);
+  };
+
   handleKeyPress = (event) => {
     const { allowDecimals = true } = this.props;
-
     if (event.key === "." && !allowDecimals) {
       event.preventDefault();
     }
+  };  
+
+  handleChange = (val) => {
+    const raw = val;
+    this.setState({ rawValue: raw });
+
+    const normalized = raw.replace(/\s/g, "").replace(",", ".");
+    const value = parseFloat(normalized);
+    this.props.onChange(isNaN(value) ? undefined : value);
   };
 
-  formatInput = (value, displayZero, displayNa, decimal) => {
-    if (!value) {
-      if (displayNa && !this.state.isEdited) {
-        return formatMessage(this.props.intl, this.props.module, "core.NumberInput.notApplicable");
-      }
-      return displayZero && value === 0 ? "0" : "";
-    }
+  handleBlur = () => {
+    const { intl, displayNa } = this.props;
+    const { rawValue } = this.state;
 
-    const numericValue = Number(value);
-
-    if (isNaN(numericValue)) return "";
-
-    if (decimal) {
-      if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 2) {
-        return parseFloat(value).toFixed(2);
-      }
-      return value;
-    }
-
-    return parseFloat(value);
-  };
-
-  handleNaBlur = () => {
-    if ((isNaN(this.props.value) || this.props.value === "") && this.state.isEdited) {
-      this.props.onChange(undefined);
-    }
     this.setState({ isEdited: false });
+
+    if ((rawValue === "" || isNaN(Number(rawValue))) && displayNa) {
+      this.setState({
+        rawValue: formatMessage(intl, this.props.module, "core.NumberInput.notApplicable"),
+      });
+      return;
+    }
+
+    const number = parseFloat(rawValue.replace(/\s/g, "").replace(",", "."));
+    if (isNaN(number)) {
+      this.setState({ rawValue: "" });
+      return;
+    }
+
+    this.setState({ rawValue: this.formatNumber(number, intl) });
+  };
+
+  handleFocus = () => {
+    this.setState({ isEdited: true });
   };
 
   render() {
@@ -54,46 +85,40 @@ class NumberInput extends Component {
       module = "core",
       min = null,
       max = null,
-      value,
       error,
-      displayZero = false,
-      displayNa = false,
       allowDecimals = true,
       ...others
     } = this.props;
-    let inputProps = { ...this.props.inputProps, type: "number", onKeyPress: this.handleKeyPress };
+
+    let inputProps = {
+      ...this.props.inputProps,
+      type: "text",
+      onKeyPress: this.handleKeyPress,
+    };
+
     let err = error;
 
-    if (min !== null) {
-      inputProps.min = min;
-      if (value < min)
-        err = formatMessageWithValues(intl, module, "validation.minValue", {
-          value,
-          min,
-        });
+    const numericValue = parseFloat(this.state.rawValue.replace(/\s/g, "").replace(",", "."));
+    if (min != null && numericValue < min) {
+      err = formatMessageWithValues(intl, module, "validation.minValue", { value: numericValue, min });
     }
-    if (max !== null) {
-      inputProps.max = max;
-      if (value > max)
-        err = formatMessageWithValues(intl, module, "validation.maxValue", {
-          value,
-          max,
-        });
+    if (max != null && numericValue > max) {
+      err = formatMessageWithValues(intl, module, "validation.maxValue", { value: numericValue, max });
     }
 
     return (
       <TextInput
         {...others}
         module={module}
-        value={value}
+        value={this.state.rawValue}
         error={err}
         inputProps={inputProps}
-        formatInput={(v) => this.formatInput(v, displayZero, displayNa, allowDecimals)}
-        onFocus={() => this.setState({ isEdited: true })}
-        onBlur={() => this.handleNaBlur()}
+        onChange={this.handleChange}
+        onBlur={this.handleBlur}
+        onFocus={this.handleFocus}
       />
     );
   }
 }
 
-export default injectIntl(NumberInput);
+export default withModulesManager(injectIntl(NumberInput));

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -3,6 +3,7 @@ import TextInput from "./TextInput";
 import { injectIntl } from "react-intl";
 import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
 import { withModulesManager } from "@openimis/fe-core";
+import FormattedNumberInput from "./FormattedNumberInput";
 
 class NumberInput extends Component {
   constructor(props) {
@@ -10,7 +11,9 @@ class NumberInput extends Component {
     this.state = {
       isEdited: false,
     };
-    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true);
+    this.numberOfDecimals = props.modulesManager.getConf("fe-core", "numberOfDecimals", 2)
+    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true)
+    this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "fr")
   }
 
   handleKeyPress = (event) => {
@@ -34,8 +37,8 @@ class NumberInput extends Component {
     if (isNaN(numericValue)) return "";
 
     if (decimal) {
-      if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 2) {
-        return parseFloat(value).toFixed(2);
+      if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 0) {
+        return parseFloat(value).toFixed(this.numberOfDecimals);
       }
       return value;
     }
@@ -84,17 +87,29 @@ class NumberInput extends Component {
     }
 
     return (
-      <TextInput
-        {...others}
-        module={module}
-        value={value}
-        error={err}
-        inputProps={inputProps}
-        formatInput={(v) => this.formatInput(v, displayZero, displayNa, allowDecimals)}
-        onFocus={() => this.setState({ isEdited: true })}
-        onBlur={() => this.handleNaBlur()}
-      />
+      <>
+        {!!this.thousandSeparator ? (
+          <FormattedNumberInput
+            {...this.props} 
+            thousandSeparator = {this.thousandSeparator}
+            numberOfDecimals = {this.numberOfDecimals}
+            pricesAreDecimal = {this.pricesAreDecimal}
+          />
+        ) : (
+          <TextInput
+            {...others}
+            module={module}
+            value={value}
+            error={err}
+            inputProps={inputProps}
+            formatInput={(v) => this.formatInput(v, displayZero, displayNa, allowDecimals)}
+            onFocus={() => this.setState({ isEdited: true })}
+            onBlur={() => this.handleNaBlur()}
+          />
+        )}
+      </>
     );
+    
   }
 }
 

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -24,8 +24,16 @@ export function formatMessageWithValues(intl, module, id, values) {
   }
 }
 
-export function formatAmount(intl, amount) {
-  return `${intl.formatMessage({ id: "currency" })} ${amount || 0}`;
+export function formatAmount(mm, intl, amount) {
+  const number = amount || 0;
+  const pricesAreDecimal = mm.getConf("fe-core", "pricesAreDecimal", true);
+
+  const formattedAmount = new Intl.NumberFormat(intl, {
+    minimumFractionDigits: pricesAreDecimal ? 2 : 0,
+    maximumFractionDigits: pricesAreDecimal ? 2 : 0,
+  }).format(number);
+
+  return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
 }
 
 export function formatDateFromISO(mm, intl, date) {

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -25,7 +25,7 @@ export function formatMessageWithValues(intl, module, id, values) {
 }
 
 export function formatAmount(mm, intl, amount) {
-  const thousandSeparator = mm.getConf("fe-core", "thousandSeparator", "fr");
+  const thousandSeparator = mm.getConf("fe-core", "thousandSeparator", "en");
   const number = amount || 0;
   const pricesAreDecimal = mm.getConf("fe-core", "pricesAreDecimal", true);
   const numberOfDecimals = mm.getConf("fe-core", "numberOfDecimals", 2);

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -25,14 +25,19 @@ export function formatMessageWithValues(intl, module, id, values) {
 }
 
 export function formatAmount(mm, intl, amount) {
+  const thousandSeparator = mm.getConf("fe-core", "thousandSeparator", "fr");
   const number = amount || 0;
   const pricesAreDecimal = mm.getConf("fe-core", "pricesAreDecimal", true);
+  const numberOfDecimals = mm.getConf("fe-core", "numberOfDecimals", 2);
+  if (!!thousandSeparator) {
+    const formattedAmount = new Intl.NumberFormat(thousandSeparator, {
+      minimumFractionDigits: pricesAreDecimal ? numberOfDecimals : 0,
+      maximumFractionDigits: pricesAreDecimal ? numberOfDecimals : 0,
+    }).format(number);
+    return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
+  } 
 
-  const formattedAmount = new Intl.NumberFormat(intl, {
-    minimumFractionDigits: pricesAreDecimal ? 2 : 0,
-    maximumFractionDigits: pricesAreDecimal ? 2 : 0,
-  }).format(number);
-
+  const formattedAmount = parseFloat(amount).toFixed(pricesAreDecimal ? numberOfDecimals : 0);
   return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
 }
 


### PR DESCRIPTION
We've created a new FormattedNumberInput component, modified the NumberInput component and formatAmount function in the i18n.js file to use configs and formatting that we have set.

we have defined three configs: "pricesAreDecimals" (default = true), "numberOfDecimals" (default = 2), and "thousandSeparator" (default = "fr").

They are used respectively to define whether prices are decimal, the number of decimals (if applicable), and the type of thousands separator.

If thousandSeparator === "en", the thousands separator is a comma and the decimal part comes after a dot.

If thousandSeparator === "fr", the thousands separator is a space and the decimal part comes after a comma.

If thousandSeparator === "", then it is not used.

screens shoots below show how prices display in numbers inputs  and how prices display in searchers when you use these configs. for searchers components, you just have to import the "formatAmount" function of i18n.js file of fe-core  and use it in the itemsFormatters of the component where you want to format prices. 

For input fields, the new component FormattedNumberInput is used whenever the config thousandSeparator !== "".

<img width="1920" height="1080" alt="Capture d’écran du 2025-09-12 16-59-05" src="https://github.com/user-attachments/assets/5346adf0-1cf9-49ef-8108-ad637d9a084d" />
<img width="1920" height="1080" alt="Capture d’écran du 2025-09-12 17-00-11" src="https://github.com/user-attachments/assets/d210c415-ffe0-49a8-b387-82a7178a7f64" />
