### PR TITLE
set a props to hide the save button OP-2568

### DIFF
--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -51,7 +51,7 @@ class Form extends Component {
 
   render() {
     const {
-      hideSaveButton = false,
+      enableSaveButton = true,
       classes,
       module,
       back,
@@ -92,7 +92,7 @@ class Form extends Component {
         condition: (!!this.state.dirty || !!openDirty) && !!save,
         content: (
           <span>
-            {!hideSaveButton && (
+            {enableSaveButton && (
               <Fab
                 color="primary"
                 disabled={!!this.state.saving || (!!canSave && !canSave())}

--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -51,6 +51,7 @@ class Form extends Component {
 
   render() {
     const {
+      hideSaveButton = false,
       classes,
       module,
       back,
@@ -91,13 +92,15 @@ class Form extends Component {
         condition: (!!this.state.dirty || !!openDirty) && !!save,
         content: (
           <span>
-            <Fab
-              color="primary"
-              disabled={!!this.state.saving || (!!canSave && !canSave())}
-              onClick={(e) => this.save(this.props.edited)}
-            >
-              <SaveIcon />
+            {!hideSaveButton && (
+              <Fab
+                color="primary"
+                disabled={!!this.state.saving || (!!canSave && !canSave())}
+                onClick={(e) => this.save(this.props.edited)}
+              >
+                <SaveIcon />
             </Fab>
+            )}
           </span>
         ),
         tooltip: saveTooltip || formatMessage(this.props.intl, module, "saveTooltip"),


### PR DESCRIPTION
we've set a props hideSaveButton to hide when necessary the save button of Form component.
this can be useful for pages that use the Form component in readOnly mode; in that case this avoid the user to be confuse