### PR TITLE
set the FilterPane expandable

### DIFF
--- a/src/components/generics/Searcher.js
+++ b/src/components/generics/Searcher.js
@@ -242,6 +242,7 @@ class Searcher extends Component {
   };
   constructor(props) {
     super(props);
+    this.miniFilterPane = props.modulesManager.getConf("fe-core", "miniFilterPane", false);
     this.fetchEnabled = props.modulesManager.getConf("fe-core", "shouldFetchInitially", true);
     this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
   }
@@ -539,6 +540,7 @@ class Searcher extends Component {
     } = this.props;
     return (
       <Fragment>
+
         {!!FilterPane && (
           <SearcherPane
             module={module}

--- a/src/components/generics/SearcherPane.js
+++ b/src/components/generics/SearcherPane.js
@@ -33,16 +33,16 @@ const styles = (theme) => ({
   panelSummary: {
     backgroundColor: theme.paper.header.backgroundColor,
     color: theme.palette.primary.main,
-    minHeight: "36px !important",   // hauteur fermée
+    minHeight: "36px !important",
     "&$expanded": {
-      minHeight: "36px !important", // hauteur ouverte
+      minHeight: "36px !important",
     },
   },
   panelExpandIcon: {
     color: theme.palette.primary.main,
   },
   panelSummaryContent: {
-    margin: "0px 0", // réduit les marges verticales
+    margin: "0px 0",
     "&$expanded": {
       margin: "0px 0",
     },
@@ -58,7 +58,7 @@ const styles = (theme) => ({
     display: "block",
   },
   expanded: {},
-  panelTitle: theme.paper.title, // on remet comme avant
+  panelTitle: theme.paper.title,
   paper: theme.paper.body,
   paperDivider: theme.paper.divider,
   paperHeaderAction: {
@@ -139,7 +139,6 @@ class SearcherPane extends Component {
           expanded={this.state.expanded}
           onChange={this.handleChange}
         >
-          {/* --- HEADER TOUJOURS VISIBLE --- */}
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon className={classes.panelExpandIcon} />}
             classes={{
@@ -148,12 +147,9 @@ class SearcherPane extends Component {
               expanded: classes.expanded,
             }}
           >
-            {/* Titre à gauche */}
             <Grid item xs className={classes.panelTitle}>
               <FormattedMessage module={module} id={title} />
             </Grid>
-
-            {/* Boutons affichés seulement si expanded === true */}
             {this.state.expanded && (
               <Grid item className={classes.paperHeader}>
                 {isCustomFiltering && (
@@ -199,26 +195,22 @@ class SearcherPane extends Component {
             )}
           </ExpansionPanelSummary>
 
-          {/* --- CONTENU DÉROULANT --- */}
           <ExpansionPanelDetails className={classes.panelDetails}>
             <Grid container spacing={1}>
-              {/* Zone des filtres */}
               {!!filterPane && (
                 <Fragment>
                   <Grid item xs={12} className={classes.paperDivider}>
                     <Divider />
                   </Grid>
-                  <Grid item xs={12}>{filterPane}</Grid>
+                  {filterPane}
                 </Fragment>
               )}
-
-              {/* Zone des résultats */}
               {!!resultsPane && (
                 <Fragment>
                   <Grid item xs={12} className={classes.paperDivider}>
                     <Divider />
                   </Grid>
-                  <Grid item xs={12}>{resultsPane}</Grid>
+                  {resultsPane}
                 </Fragment>
               )}
             </Grid>

--- a/src/components/generics/SearcherPane.js
+++ b/src/components/generics/SearcherPane.js
@@ -1,10 +1,20 @@
 import React, { Component, Fragment } from "react";
 import { injectIntl } from "react-intl";
 import _debounce from "lodash/debounce";
-
-import { Grid, Paper, Divider } from "@material-ui/core";
+import {
+  ExpansionPanel,
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
+  Grid,
+  Paper,
+  Divider,
+} from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { YoutubeSearchedFor as ResetFilterIcon, Search as DefaultSearchIcon } from "@material-ui/icons";
+import {
+  YoutubeSearchedFor as ResetFilterIcon,
+  Search as DefaultSearchIcon,
+  ExpandMore as ExpandMoreIcon,
+} from "@material-ui/icons";
 
 import { SearcherActionButton } from "@openimis/fe-core";
 import { DEFAULT_DEBOUNCE_TIME, ENTER_KEY } from "../../constants";
@@ -13,20 +23,69 @@ import AdvancedFiltersDialog from "../dialogs/AdvancedFiltersDialog";
 import FormattedMessage from "./FormattedMessage";
 
 const styles = (theme) => ({
+  panel: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.common.white,
+    "&:before": {
+      display: "none",
+    },
+  },
+  panelSummary: {
+    backgroundColor: theme.paper.header.backgroundColor,
+    color: theme.palette.primary.main,
+    minHeight: "36px !important",   // hauteur fermée
+    "&$expanded": {
+      minHeight: "36px !important", // hauteur ouverte
+    },
+  },
+  panelExpandIcon: {
+    color: theme.palette.primary.main,
+  },
+  panelSummaryContent: {
+    margin: "0px 0", // réduit les marges verticales
+    "&$expanded": {
+      margin: "0px 0",
+    },
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    width: "100%",
+  },
+  expanded: {},
+  panelTitle: theme.paper.title, // on remet comme avant
   paper: theme.paper.body,
-  paperHeader: { ...theme.paper.header, display: "flex", justifyContent: "flex-end", itemAlign: "center" },
-  paperHeaderTitle: theme.paper.title,
-  paperHeaderAction: { ...theme.paper.action, display: "flex", justifyContent: "center", itemAlign: "center" },
   paperDivider: theme.paper.divider,
+  paperHeaderAction: {
+    ...theme.paper.action,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  paperHeader: { 
+    ...theme.paper.header, 
+    display: "flex", 
+    justifyContent: "flex-end", 
+    alignItems: "center" 
+  },
 });
 
 class SearcherPane extends Component {
+  state = {
+    expanded: false,
+  };
+
   constructor(props) {
     super(props);
     const { refresh = () => {}, reset = () => {} } = this.props;
     this.debouncedRefresh = _debounce(refresh, DEFAULT_DEBOUNCE_TIME);
     this.debouncedReset = _debounce(reset, DEFAULT_DEBOUNCE_TIME);
   }
+
+  handleChange = (event, isExpanded) => {
+    this.setState({
+      expanded: isExpanded,
+    });
+  };
 
   handleKeyDown = (event) => {
     if (event.key === ENTER_KEY) {
@@ -48,7 +107,6 @@ class SearcherPane extends Component {
       module,
       del,
       title = "search.title",
-      split = 8,
       filterPane,
       filters,
       resultsPane = null,
@@ -67,16 +125,32 @@ class SearcherPane extends Component {
       setAppliedFiltersRowStructure = null,
       applyNumberCircle = null,
     } = this.props;
+
     return (
       <Paper className={classes.paper}>
-        <Grid container>
-          <Grid item xs={split} className={classes.paperHeaderTitle}>
-            <FormattedMessage module={module} id={title} />
-          </Grid>
-          <Grid item xs={12 - split} className={classes.paperHeader}>
-            {(!!actions || !!refresh) && (
-              <>
-                {isCustomFiltering === true ? (
+        <ExpansionPanel
+          className={classes.panel}
+          expanded={this.state.expanded}
+          onChange={this.handleChange}
+        >
+          {/* --- HEADER TOUJOURS VISIBLE --- */}
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon className={classes.panelExpandIcon} />}
+            classes={{
+              root: classes.panelSummary,
+              content: classes.panelSummaryContent,
+              expanded: classes.expanded,
+            }}
+          >
+            {/* Titre à gauche */}
+            <Grid item xs className={classes.panelTitle}>
+              <FormattedMessage module={module} id={title} />
+            </Grid>
+
+            {/* Boutons affichés seulement si expanded === true */}
+            {this.state.expanded && (
+              <Grid item className={classes.paperHeader}>
+                {isCustomFiltering && (
                   <AdvancedFiltersDialog
                     object={objectForCustomFiltering}
                     additionalParams={additionalCustomFilterParams}
@@ -91,59 +165,59 @@ class SearcherPane extends Component {
                     searchCriteria={filters}
                     deleteFilter={del}
                   />
-                ) : (
-                  <></>
                 )}
                 {!!actions &&
                   actions.map((a, idx) => (
-                    <Grid item key={`action-${idx}`} className={classes.paperHeaderAction}>
-                      <SearcherActionButton
-                        onClick={a.action}
-                        startIcon={a.icon}
-                        label={a.label || ''}
-                      />
-                    </Grid>
+                    <SearcherActionButton
+                      key={`action-${idx}`}
+                      onClick={a.action}
+                      startIcon={a.icon}
+                      label={a.label || ""}
+                    />
                   ))}
                 {!!reset && (
-                  <Grid item key={`action-reset`} className={classes.paperHeaderAction}>
-                    <SearcherActionButton
-                      startIcon={<ResetFilterIcon />}
-                      onClick={this.debouncedReset}
-                      label={formatMessage(this.props.intl, module, "resetFilterTooltip")}
-                    />
-                  </Grid>
+                  <SearcherActionButton
+                    startIcon={<ResetFilterIcon />}
+                    onClick={this.debouncedReset}
+                    label={formatMessage(this.props.intl, module, "resetFilterTooltip")}
+                  />
                 )}
                 {!!refresh && (
-                  <Grid item key={`action-refresh`} className={classes.paperHeaderAction}>
-                    <SearcherActionButton
-                      startIcon={<DefaultSearchIcon />}
-                      onClick={this.debouncedRefresh}
-                      label={formatMessage(this.props.intl, module, "refreshFilterTooltip")}
-                    />
-                  </Grid>
+                  <SearcherActionButton
+                    startIcon={<DefaultSearchIcon />}
+                    onClick={this.debouncedRefresh}
+                    label={formatMessage(this.props.intl, module, "refreshFilterTooltip")}
+                  />
                 )}
-              </>
+              </Grid>
             )}
-          </Grid>
-          {!!filterPane && (
-            <Fragment>
-              <Grid item xs={12} className={classes.paperDivider}>
-                <Divider />
-              </Grid>
-              {filterPane}
-            </Fragment>
-          )}
-          {!!resultsPane && (
-            <Fragment>
-              <Grid item xs={12} className={classes.paperDivider}>
-                <Divider />
-              </Grid>
-              <Grid item xs={12}>
-                {resultsPane}
-              </Grid>
-            </Fragment>
-          )}
-        </Grid>
+          </ExpansionPanelSummary>
+
+          {/* --- CONTENU DÉROULANT --- */}
+          <ExpansionPanelDetails style={{ display: "block", width: "100%" }}>
+            <Grid container spacing={1}>
+              {/* Zone des filtres */}
+              {!!filterPane && (
+                <Fragment>
+                  <Grid item xs={12} className={classes.paperDivider}>
+                    <Divider />
+                  </Grid>
+                  <Grid item xs={12}>{filterPane}</Grid>
+                </Fragment>
+              )}
+
+              {/* Zone des résultats */}
+              {!!resultsPane && (
+                <Fragment>
+                  <Grid item xs={12} className={classes.paperDivider}>
+                    <Divider />
+                  </Grid>
+                  <Grid item xs={12}>{resultsPane}</Grid>
+                </Fragment>
+              )}
+            </Grid>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
       </Paper>
     );
   }

--- a/src/components/generics/SearcherPane.js
+++ b/src/components/generics/SearcherPane.js
@@ -24,7 +24,7 @@ import FormattedMessage from "./FormattedMessage";
 
 const styles = (theme) => ({
   panel: {
-    margin: theme.spacing(1),
+    margin: theme.spacing(0),
     backgroundColor: theme.palette.common.white,
     "&:before": {
       display: "none",
@@ -50,6 +50,12 @@ const styles = (theme) => ({
     justifyContent: "space-between",
     alignItems: "center",
     width: "100%",
+  },
+  panelDetails: {
+    backgroundColor: theme.paper.body.backgroundColor,
+    padding: theme.spacing(2),
+    width: "100%",
+    display: "block",
   },
   expanded: {},
   panelTitle: theme.paper.title, // on remet comme avant
@@ -194,7 +200,7 @@ class SearcherPane extends Component {
           </ExpansionPanelSummary>
 
           {/* --- CONTENU DÉROULANT --- */}
-          <ExpansionPanelDetails style={{ display: "block", width: "100%" }}>
+          <ExpansionPanelDetails className={classes.panelDetails}>
             <Grid container spacing={1}>
               {/* Zone des filtres */}
               {!!filterPane && (


### PR DESCRIPTION
In order to improve the user experience, we proposed placing the FilterPane—which often becomes very large—inside an expandable component to enhance visibility in the Searcher components.

<img width="1853" height="939" alt="Capture d’écran du 2025-09-25 17-35-57" src="https://github.com/user-attachments/assets/2d868742-54e0-4ec8-956e-6e60da0dbaea" />
<img width="1853" height="939" alt="Capture d’écran du 2025-09-25 17-36-04" src="https://github.com/user-attachments/assets/61328fb4-6f57-47e3-bd9f-262abac93d56" />
