### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -96,7 +96,8 @@ class Form extends Component {
               disabled={!!this.state.saving || (!!canSave && !canSave())}
               onClick={(e) => this.save(this.props.edited)}
             >
-              <SaveIcon />
+              save
+              {/*<SaveIcon />*/}
             </Fab>
           </span>
         ),

--- a/src/components/generics/Form.js
+++ b/src/components/generics/Form.js
@@ -96,8 +96,7 @@ class Form extends Component {
               disabled={!!this.state.saving || (!!canSave && !canSave())}
               onClick={(e) => this.save(this.props.edited)}
             >
-              save
-              {/*<SaveIcon />*/}
+              <SaveIcon />
             </Fab>
           </span>
         ),

--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 
-import { Grid, FormControlLabel, Checkbox, Fab, IconButton } from "@material-ui/core";
+import { Grid, FormControlLabel, Checkbox, Fab, Button } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import AddIcon from "@material-ui/icons/Add";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -233,9 +233,9 @@ class Roles extends Component {
       result.push((role) =>
         withTooltip(
           <div>
-            <IconButton href={this.roleUpdatePageUrl(role)} disabled={this.isRowDisabled(null, role)}>
-              <EditIcon />
-            </IconButton>
+            <Button startIcon={<EditIcon />} onClick={() => this.onUpdate(role)} disabled={this.isRowDisabled(null, role)}>
+              {formatMessage(intl, "core", "roleManagement.editButton.buttonText")}
+            </Button>
           </div>,
           formatMessage(intl, "core", "roleManagement.editButton.tooltip"),
         ),
@@ -245,9 +245,9 @@ class Roles extends Component {
       result.push((role) =>
         withTooltip(
           <div>
-            <IconButton href={this.roleDuplicatePageUrl(role)} disabled={this.isRowDisabled(null, role)}>
-              <SupervisedUserCircleIcon />
-            </IconButton>
+            <Button startIcon={<SupervisedUserCircleIcon />} onClick={() => this.onDuplicate(role)} disabled={this.isRowDisabled(null, role)}>
+              {formatMessage(intl, "core", "roleManagement.duplicateButton.buttonText")}
+            </Button>
           </div>,
           formatMessage(intl, "core", "roleManagement.duplicateButton.tooltip"),
         ),
@@ -257,9 +257,9 @@ class Roles extends Component {
       result.push((role) =>
         withTooltip(
           <div>
-            <IconButton onClick={() => this.onDelete(role)} disabled={this.isRowDisabled(null, role)}>
-              <DeleteIcon />
-            </IconButton>
+            <Button startIcon={<DeleteIcon />} onClick={() => this.onDelete(role)} disabled={this.isRowDisabled(null, role)}>
+              {formatMessage(intl, "core", "roleManagement.deleteButton.buttonText")}
+            </Button>
           </div>,
           formatMessage(intl, "core", "roleManagement.deleteButton.tooltip"),
         ),

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -223,13 +223,14 @@
   "api_fhir_r4.R4_fhir_subscription_config_fhir_sub_delete_perms": "Api Fhir R4 | Subscription Config Fhir Sub Delete",
   "api_etl.gql_query_api_etl_rule_perms": "Api Etl | Query Api Etl Rule",
   "api_etl.gql_mutation_execute_api_etl_rule_perms": "Api Etl | Mutation Execute Api Etl Rule",
-  "core.openNewTab": "Open in new tab",
-  "core.delete": "Delete",
-  "core.create": "Create New",
-  "core.edit": "Edit",
-  "core.cancel": "Cancel",
-  "core.save": "Save",
-  "core.back": "Back",
-  "core.addExisting": "Ajouter"
-
+  "core.openNewTab.buttonText": "Open",
+  "core.delete.buttonText": "Delete",
+  "core.create.buttonText": "Create New",
+  "core.edit.buttonText": "Edit",
+  "core.cancel.buttonText": "Cancel",
+  "core.save.buttonText": "Save",
+  "core.back.buttonText": "Back",
+  "roleManagement.editButton.buttonText": "Edit",
+  "roleManagement.duplicateButton.buttonText": "Duplicate",
+  "roleManagement.deleteButton.buttonText": "Delete"
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -222,5 +222,14 @@
   "api_fhir_r4.R4_fhir_subscription_config_fhir_sub_update_perms": "Api Fhir R4 | Subscription Config Fhir Sub Update",
   "api_fhir_r4.R4_fhir_subscription_config_fhir_sub_delete_perms": "Api Fhir R4 | Subscription Config Fhir Sub Delete",
   "api_etl.gql_query_api_etl_rule_perms": "Api Etl | Query Api Etl Rule",
-  "api_etl.gql_mutation_execute_api_etl_rule_perms": "Api Etl | Mutation Execute Api Etl Rule"
+  "api_etl.gql_mutation_execute_api_etl_rule_perms": "Api Etl | Mutation Execute Api Etl Rule",
+  "core.openNewTab": "Open in new tab",
+  "core.delete": "Delete",
+  "core.create": "Create New",
+  "core.edit": "Edit",
+  "core.cancel": "Cancel",
+  "core.save": "Save",
+  "core.back": "Back",
+  "core.addExisting": "Ajouter"
+
 }


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.