### PR TITLE
OP-2799: put the pagination block on the left

### DIFF
--- a/src/components/generics/Table.js
+++ b/src/components/generics/Table.js
@@ -39,7 +39,10 @@ const styles = (theme) => ({
   tableHighlightedAltCell: theme.table.highlightedAltCell,
   tableDisabledRow: theme.table.disabledRow,
   tableDisabledCell: theme.table.disabledCell,
-  tableFooter: theme.table.footer,
+  tableFooter: {
+    ...theme.table.footer,
+    display: 'flex',
+  },
   pager: theme.table.pager,
   left: {
     textAlign: "left",


### PR DESCRIPTION
this change permits to avoid user to have to scroll right to find out the pagination block when the table content is very large

<img width="1854" height="188" alt="Capture d’écran du 2025-10-22 11-35-51" src="https://github.com/user-attachments/assets/df0cda4c-4f0c-4b7a-a196-e659032f96aa" />
<img width="1854" height="188" alt="Capture d’écran du 2025-10-22 11-36-50" src="https://github.com/user-attachments/assets/7990acd0-edad-4587-91a3-ce2cfdc3c5f6" />
