### PR TITLE
OP-2795: show message no options in pricelistPickers when they have none

### DIFF
--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -70,7 +70,7 @@ class SelectInput extends Component {
       required = false,
       placeholder,
       title = '',
-      noOptionsText = <FormattedMessage module="core" id="noOptions" />
+      pickerNoOptionsLabel = <FormattedMessage module="core" id="pickerNoOptionsLabel" />
     } = this.props;
     if (!options) return null;
     let valueStr = null;
@@ -107,7 +107,7 @@ class SelectInput extends Component {
 
               {options.length === 0 && (
                 <MenuItem disabled>
-                  {noOptionsText}
+                  {pickerNoOptionsLabel}
                 </MenuItem>
               )}
 

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -76,6 +76,9 @@ class SelectInput extends Component {
     if (!!readOnly) {
       valueStr = options.filter((o) => JSON.stringify(o.value) === JSON.stringify(value)).map((o) => o.label);
     }
+    const moduleProp = this.props.intl.messages[`${module}.pickerNoOptionsLabel`] ? module : "core";
+    console.log("moduleProp", moduleProp);
+    console.log("module", module);
     return (
       <Fragment>
         {!readOnly && (
@@ -106,7 +109,7 @@ class SelectInput extends Component {
 
               {options.length === 0 && (
                 <MenuItem disabled key={`${module}-${name}-option-0`}>
-                  <FormattedMessage module={module} id="pickerNoOptionsLabel" />
+                  <FormattedMessage module={moduleProp} id="pickerNoOptionsLabel" />
                 </MenuItem>
               )}
 

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -77,8 +77,7 @@ class SelectInput extends Component {
       valueStr = options.filter((o) => JSON.stringify(o.value) === JSON.stringify(value)).map((o) => o.label);
     }
     const moduleProp = this.props.intl.messages[`${module}.pickerNoOptionsLabel`] ? module : "core";
-    console.log("moduleProp", moduleProp);
-    console.log("module", module);
+    
     return (
       <Fragment>
         {!readOnly && (

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -70,7 +70,6 @@ class SelectInput extends Component {
       required = false,
       placeholder,
       title = '',
-      pickerNoOptionsLabel = <FormattedMessage module="core" id="pickerNoOptionsLabel" />
     } = this.props;
     if (!options) return null;
     let valueStr = null;
@@ -106,8 +105,8 @@ class SelectInput extends Component {
               )}
 
               {options.length === 0 && (
-                <MenuItem disabled>
-                  {pickerNoOptionsLabel}
+                <MenuItem disabled key={`${module}-${name}-option-0`}>
+                  <FormattedMessage module={module} id="pickerNoOptionsLabel" />
                 </MenuItem>
               )}
 

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -70,6 +70,7 @@ class SelectInput extends Component {
       required = false,
       placeholder,
       title = '',
+      noOptionsText = <FormattedMessage module="core" id="noOptions" />
     } = this.props;
     if (!options) return null;
     let valueStr = null;
@@ -106,7 +107,7 @@ class SelectInput extends Component {
 
               {options.length === 0 && (
                 <MenuItem disabled>
-                  <FormattedMessage module="core" id="noOptions" />
+                  {noOptionsText}
                 </MenuItem>
               )}
 

--- a/src/components/inputs/SelectInput.js
+++ b/src/components/inputs/SelectInput.js
@@ -90,13 +90,12 @@ class SelectInput extends Component {
                 id: `${_.uuid()}-input`,
                 title: title,
               }}
-              value={!!value ? JSON.stringify(value) : null}
+              value={!!value ? JSON.stringify(value) : ""}
               onChange={this._onChange}
               IconComponent={this.renderIconComponent()}
               disabled={disabled}
               endAdornment={this.renderEndAdornment()}
               displayEmpty
-              //NOTE: We want to get rid of default styling (marginTop) if label is not rendered
               {...(withLabel ? null : { style: { marginTop: "0px" } })}
             >
               {placeholder && (
@@ -104,11 +103,20 @@ class SelectInput extends Component {
                   <FormattedMessage module={module} id={placeholder} />
                 </MenuItem>
               )}
-              {options.map((option, idx) => (
-                <MenuItem key={`${module}-${name}-option-${idx}`} value={JSON.stringify(option.value)}>
-                  {option.label}
+
+              {options.length === 0 && (
+                <MenuItem disabled>
+                  <FormattedMessage module="core" id="noOptions" />
                 </MenuItem>
-              ))}
+              )}
+
+              {options.length > 0 &&
+                options.map((option, idx) => (
+                  <MenuItem key={`${module}-${name}-option-${idx}`} value={JSON.stringify(option.value)}>
+                    {option.label}
+                  </MenuItem>
+                ))
+              }
             </Select>
           </FormControl>
         )}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "core.noOptions": "No options available",
   "core.roleManagement.label": "Roles Management",
   "core.roleManagement.searcher.results.title": "{rolesTotalCount} Roles Found",
   "core.roleManagement.roleName": "Role Name",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "core.noOptions": "No options available",
+  "core.pickerNoOptionsLabel": "No options available",
   "core.roleManagement.label": "Roles Management",
   "core.roleManagement.searcher.results.title": "{rolesTotalCount} Roles Found",
   "core.roleManagement.roleName": "Role Name",


### PR DESCRIPTION
In the HF form, when no price list matches the HF location, a thin white block is displayed instead of a list, which can be confusing for the user. Therefore, we proposed displaying a "no options" message when no choices are available in the picker.

<img width="1779" height="529" alt="Capture d’écran du 2025-11-17 16-45-27" src="https://github.com/user-attachments/assets/915e31f7-20e0-4ceb-b2cf-e503c310695e" />
<img width="1200" height="506" alt="Screenshot 2025-11-17 at 10 08 54 AM" src="https://github.com/user-attachments/assets/9bcd51b2-86ed-4ff3-9c00-547e18fa639f" />
