### PR TITLE
handle the csrftoken error on release

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -271,8 +271,86 @@ export function fetch(config) {
           },
         },
       });
+
+      const endpoint = config.endpoint;
+      const payload = action?.payload || {};
+      const response = payload?.response;
+      const status = response?.status;
+      const statusText = response?.statusText;
+      const gqlErrors = payload?.errors || response?.errors || [];
+      const message = payload?.message || action?.error?.message;
+
+      if (action.error) {
+        let errorMessage = "";
+
+        if (!response && !message) {
+          errorMessage = "Server not responding";
+        } else if (status) {
+          errorMessage = `HTTP ${status}: ${statusText || "Unknown status"}`;
+        } else if (gqlErrors?.length > 0) {
+          errorMessage = `GraphQL Error: ${gqlErrors.map(e => e.message).join("; ")}`;
+        } else if (message) {
+          errorMessage = `Network or API Error: ${message}`;
+        } else {
+          errorMessage = "Unknown error during API call";
+        }
+
+        Sentry.captureException(new Error(errorMessage), {
+          level: "error",
+          tags: {
+            endpoint,
+            status: status || "no-status",
+            type: config.method || "unknown-method",
+          },
+          extra: {
+            endpoint,
+            status,
+            statusText,
+            body: config.body,
+            response: action.payload,
+          },
+        });
+      }
+
+      if (!action.error && gqlErrors?.length > 0) {
+        const gqlMessage = gqlErrors.map(e => e.message).join("; ");
+
+        Sentry.captureException(new Error(`GraphQL Error: ${gqlMessage}`), {
+          level: "error",
+          tags: {
+            endpoint,
+            type: config.method || "unknown-method",
+          },
+          extra: {
+            endpoint,
+            errors: gqlErrors,
+            query: config.body,
+          },
+        });
+      }
+
+      const norm = (m) => String(m || "").toLowerCase().replace(/['"]/g, "").trim();
+      const csrfError = gqlErrors.some((e) => {
+        const msg = norm(e?.message);
+        return msg === "csrftoken" 
+        || msg === "user not authorized for this operation" 
+        || msg === "unauthorized";
+      });
+
+      if (csrfError) {
+        dispatch(
+          coreConfirm(
+            "Session Expired",
+            "Your session has expired, You will be redirected to the login page.",
+            "csrf_logout"
+          )
+        );
+        return action;
+      }
+
     } catch (err) {
       const errorMessage = "Server not responding";
+
       Sentry.captureException(new Error(errorMessage), {
         level: "error",
         tags: {
@@ -285,64 +363,8 @@ export function fetch(config) {
           originalError: err,
         },
       });
-      return {
-        error: true,
-        payload: { message: errorMessage },
-      };
-    }
 
-    const endpoint = config.endpoint;
-    const response = action?.payload?.response;
-    const status = response?.status;
-    const statusText = response?.statusText;
-    const gqlErrors = response?.errors;
-    const message = action?.payload?.message || action?.error?.message;
-    
-    if (action.error) {
-      let errorMessage = "";
-      if (!response && !message) {
-        errorMessage = "Server not responding";
-      }
-      if (status) {
-        errorMessage = `HTTP ${status}: ${statusText || "Unknown status"}`;
-      } else if (gqlErrors?.length > 0) {
-        errorMessage = `GraphQL Error: ${gqlErrors.map(e => e.message).join("; ")}`;
-      } else if (message) {
-        errorMessage = `Network or API Error: ${message}`;
-      } else {
-        errorMessage = "Unknown error during API call";
-      }
-
-      Sentry.captureException(new Error(errorMessage), {
-        level: "error",
-        tags: {
-          endpoint,
-          status: status || "no-status",
-          type: config.method || "unknown-method",
-        },
-        extra: {
-          endpoint,
-          status,
-          statusText,
-          body: config.body,
-          response: action.payload,
-        },
-      });
-    }
-
-    if (!action.error && gqlErrors && gqlErrors.length > 0) {
-      Sentry.captureException(new Error(`GraphQL Error: ${gqlErrors.map(e => e.message).join("; ")}`), {
-        level: "error",
-        tags: {
-          endpoint,
-          type: config.method || "unknown-method",
-        },
-        extra: {
-          endpoint,
-          errors: gqlErrors,
-          query: config.body,
-        },
-      });
+      throw err;
     }
 
     return action;
@@ -529,9 +551,9 @@ export function clearAlert() {
   };
 }
 
-export function coreConfirm(title, message) {
+export function coreConfirm(title, message, intent = null) {
   return (dispatch) => {
-    dispatch({ type: "CORE_CONFIRM", payload: { title, message } });
+    dispatch({ type: "CORE_CONFIRM", payload: { title, message, intent } });
   };
 }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect, useState } from "react";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { IntlProvider } from "react-intl";
 import { Route, BrowserRouter, Switch } from "react-router-dom";
 import { CssBaseline } from "@material-ui/core";
@@ -51,6 +51,7 @@ const App = (props) => {
     classes,
     error,
     confirm,
+    confirmed,
     user,
     messages,
     clearConfirm,
@@ -61,11 +62,13 @@ const App = (props) => {
     rights,
     ...others
   } = props;
+  const dispatch = useDispatch();
 
   const economicUnitConfig = modulesManager.getConf("fe-core", "App.economicUnitConfig", false);
 
   const [economicUnitDialogOpen, setEconomicUnitDialogOpen] = useState(false);
   const [isSecondaryCalendar, setSecondaryCalendar] = useBoolean(true);
+  const [lastConfirmIntent, setLastConfirmIntent] = useState(null);
 
   const auth = useAuthentication();
   const routes = useMemo(() => {
@@ -128,6 +131,21 @@ const App = (props) => {
     localStorage.setItem("isSecondaryCalendarEnabled", JSON.stringify(!isSecondaryCalendar));
     toggleCurrentCalendarType(!isSecondaryCalendar);
   }, [isSecondaryCalendar]);
+
+  useEffect(() => {
+    if (confirm?.intent) {
+      setLastConfirmIntent(confirm.intent);
+    }
+  }, [confirm]);
+
+  useEffect(() => {
+    const handleConfirm = async () => {
+      if (confirmed === true && lastConfirmIntent === "csrf_logout") {
+        await onLogout(dispatch);
+      }
+    };
+    handleConfirm();
+  }, [confirmed, lastConfirmIntent, dispatch]);
 
   if (error) {
     return (
@@ -226,6 +244,7 @@ const mapStateToProps = (state) => ({
   user: state.core.user?.i_user,
   error: state.core.error,
   confirm: state.core.confirm,
+  confirmed: state.core.confirmed,
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({ clearConfirm, toggleCurrentCalendarType }, dispatch);

--- a/src/pages/Role.js
+++ b/src/pages/Role.js
@@ -84,7 +84,11 @@ class Role extends Component {
           this.props.fetchRole([`clientMutationId: "${this.props.mutation.clientMutationId}"`]),
         );
       }
-    } else if (prevProps.confirmed !== this.props.confirmed && !!this.props.confirmed && !!this.state.confirmedAction) {
+    } else if (
+      prevProps.confirmed !== this.props.confirmed &&
+      !!this.props.confirmed &&
+      typeof this.state.confirmedAction === "function"
+    ) {
       this.state.confirmedAction();
     }
   }

--- a/src/pages/Roles.js
+++ b/src/pages/Roles.js
@@ -170,7 +170,11 @@ class Roles extends Component {
     if (prevProps.submittingMutation && !this.props.submittingMutation) {
       this.props.journalize(this.props.mutation);
       this.setState((state) => ({ deleted: state.deleted.concat(state.toDelete) }));
-    } else if (prevProps.confirmed !== this.props.confirmed && !!this.props.confirmed && !!this.state.confirmedAction) {
+    } else if (
+      prevProps.confirmed !== this.props.confirmed &&
+      !!this.props.confirmed &&
+      typeof this.state.confirmedAction === "function"
+    ) {
       this.state.confirmedAction();
     }
   }


### PR DESCRIPTION
In the release, we observed that when a user remains logged in for 8 hours, a request to the backend fails and instead returns a payload containing `errors[0].message = "csrftoken"`, as shown in the screenshot. This is caused by the user's session expiring. We therefore proposed catching and better handling this error on the front end by redirecting the user to the login page so they can reset their session.

<img width="1852" height="1072" alt="Capture d’écran du 2025-11-27 13-00-38" src="https://github.com/user-attachments/assets/ccb49a5f-bebd-4db6-93bf-a91090ff07c9" />
