### PR TITLE
fix: remove default-collapsed state from SearcherPane - OP-2845

### DIFF
--- a/src/components/generics/SearcherPane.js
+++ b/src/components/generics/SearcherPane.js
@@ -2,9 +2,6 @@ import React, { Component, Fragment } from "react";
 import { injectIntl } from "react-intl";
 import _debounce from "lodash/debounce";
 import {
-  ExpansionPanel,
-  ExpansionPanelSummary,
-  ExpansionPanelDetails,
   Grid,
   Paper,
   Divider,
@@ -13,7 +10,6 @@ import { withTheme, withStyles } from "@material-ui/core/styles";
 import {
   YoutubeSearchedFor as ResetFilterIcon,
   Search as DefaultSearchIcon,
-  ExpandMore as ExpandMoreIcon,
 } from "@material-ui/icons";
 
 import { SearcherActionButton } from "@openimis/fe-core";
@@ -26,30 +22,15 @@ const styles = (theme) => ({
   panel: {
     margin: theme.spacing(0),
     backgroundColor: theme.palette.common.white,
-    "&:before": {
-      display: "none",
-    },
   },
   panelSummary: {
     backgroundColor: theme.paper.header.backgroundColor,
     color: theme.palette.primary.main,
-    minHeight: "36px !important",
-    "&$expanded": {
-      minHeight: "36px !important",
-    },
-  },
-  panelExpandIcon: {
-    color: theme.palette.primary.main,
-  },
-  panelSummaryContent: {
-    margin: "0px 0",
-    "&$expanded": {
-      margin: "0px 0",
-    },
+    minHeight: "36px",
     display: "flex",
     justifyContent: "space-between",
     alignItems: "center",
-    width: "100%",
+    padding: theme.spacing(0, 2),
   },
   panelDetails: {
     backgroundColor: theme.paper.body.backgroundColor,
@@ -57,7 +38,6 @@ const styles = (theme) => ({
     width: "100%",
     display: "block",
   },
-  expanded: {},
   panelTitle: theme.paper.title,
   paper: theme.paper.body,
   paperDivider: theme.paper.divider,
@@ -67,31 +47,21 @@ const styles = (theme) => ({
     justifyContent: "center",
     alignItems: "center",
   },
-  paperHeader: { 
-    ...theme.paper.header, 
-    display: "flex", 
-    justifyContent: "flex-end", 
-    alignItems: "center" 
+  paperHeader: {
+    ...theme.paper.header,
+    display: "flex",
+    justifyContent: "flex-end",
+    alignItems: "center"
   },
 });
 
 class SearcherPane extends Component {
-  state = {
-    expanded: false,
-  };
-
   constructor(props) {
     super(props);
     const { refresh = () => {}, reset = () => {} } = this.props;
     this.debouncedRefresh = _debounce(refresh, DEFAULT_DEBOUNCE_TIME);
     this.debouncedReset = _debounce(reset, DEFAULT_DEBOUNCE_TIME);
   }
-
-  handleChange = (event, isExpanded) => {
-    this.setState({
-      expanded: isExpanded,
-    });
-  };
 
   handleKeyDown = (event) => {
     if (event.key === ENTER_KEY) {
@@ -136,68 +106,55 @@ class SearcherPane extends Component {
 
     return (
       <Paper className={classes.paper}>
-        <ExpansionPanel
-          className={classes.panel}
-          expanded={this.state.expanded}
-          onChange={this.handleChange}
-        >
-          <ExpansionPanelSummary
-            expandIcon={<ExpandMoreIcon className={classes.panelExpandIcon} />}
-            classes={{
-              root: classes.panelSummary,
-              content: classes.panelSummaryContent,
-              expanded: classes.expanded,
-            }}
-          >
+        <div className={classes.panel}>
+          <div className={classes.panelSummary}>
             <Grid item xs className={classes.panelTitle}>
               <FormattedMessage module={module} id={title} />
             </Grid>
-            {this.state.expanded && (
-              <Grid item className={classes.paperHeader}>
-                {isCustomFiltering && (
-                  <AdvancedFiltersDialog
-                    object={objectForCustomFiltering}
-                    additionalParams={additionalCustomFilterParams}
-                    moduleName={moduleName}
-                    objectType={objectType}
-                    setAppliedCustomFilters={setAppliedCustomFilters}
-                    appliedCustomFilters={appliedCustomFilters}
-                    onChangeFilters={onChangeFilters}
-                    appliedFiltersRowStructure={appliedFiltersRowStructure}
-                    setAppliedFiltersRowStructure={setAppliedFiltersRowStructure}
-                    applyNumberCircle={applyNumberCircle}
-                    searchCriteria={filters}
-                    deleteFilter={del}
-                  />
-                )}
-                {!!actions &&
-                  actions.map((a, idx) => (
-                    <SearcherActionButton
-                      key={`action-${idx}`}
-                      onClick={a.action}
-                      startIcon={a.icon}
-                      label={a.label || ""}
-                    />
-                  ))}
-                {!!reset && (
+            <Grid item className={classes.paperHeader}>
+              {isCustomFiltering && (
+                <AdvancedFiltersDialog
+                  object={objectForCustomFiltering}
+                  additionalParams={additionalCustomFilterParams}
+                  moduleName={moduleName}
+                  objectType={objectType}
+                  setAppliedCustomFilters={setAppliedCustomFilters}
+                  appliedCustomFilters={appliedCustomFilters}
+                  onChangeFilters={onChangeFilters}
+                  appliedFiltersRowStructure={appliedFiltersRowStructure}
+                  setAppliedFiltersRowStructure={setAppliedFiltersRowStructure}
+                  applyNumberCircle={applyNumberCircle}
+                  searchCriteria={filters}
+                  deleteFilter={del}
+                />
+              )}
+              {!!actions &&
+                actions.map((a, idx) => (
                   <SearcherActionButton
-                    startIcon={<ResetFilterIcon />}
-                    onClick={this.debouncedReset}
-                    label={formatMessage(this.props.intl, module, "resetFilterTooltip")}
+                    key={`action-${idx}`}
+                    onClick={a.action}
+                    startIcon={a.icon}
+                    label={a.label || ""}
                   />
-                )}
-                {!!refresh && (
-                  <SearcherActionButton
-                    startIcon={<DefaultSearchIcon />}
-                    onClick={this.debouncedRefresh}
-                    label={formatMessage(this.props.intl, module, "refreshFilterTooltip")}
-                  />
-                )}
-              </Grid>
-            )}
-          </ExpansionPanelSummary>
+                ))}
+              {!!reset && (
+                <SearcherActionButton
+                  startIcon={<ResetFilterIcon />}
+                  onClick={this.debouncedReset}
+                  label={formatMessage(this.props.intl, module, "resetFilterTooltip")}
+                />
+              )}
+              {!!refresh && (
+                <SearcherActionButton
+                  startIcon={<DefaultSearchIcon />}
+                  onClick={this.debouncedRefresh}
+                  label={formatMessage(this.props.intl, module, "refreshFilterTooltip")}
+                />
+              )}
+            </Grid>
+          </div>
 
-          <ExpansionPanelDetails className={classes.panelDetails}>
+          <div className={classes.panelDetails}>
             <Grid container spacing={1}>
               {!!filterPane && (
                 <Fragment>
@@ -216,8 +173,8 @@ class SearcherPane extends Component {
                 </Fragment>
               )}
             </Grid>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
+          </div>
+        </div>
       </Paper>
     );
   }


### PR DESCRIPTION
## Summary

- `SearcherPane` was wrapped in a Material-UI `ExpansionPanel` initialised with `expanded: false`, causing the filter pane to be **collapsed on every page load**
- This broke all E2E tests that interact with filter fields — Cypress cannot find or interact with inputs inside a collapsed panel, causing widespread test failures across the grievance module and other modules
- Clicking the "Advanced Filters" button triggered the `ExpansionPanel` toggle, **collapsing the panel** instead of opening the dialog — a direct UX regression caused by event bubbling into the accordion
- Replaced `ExpansionPanel / ExpansionPanelSummary / ExpansionPanelDetails` with plain `div` wrappers so the filter pane is always visible
- Removed the now-unnecessary `state`, `handleChange`, and `expanded` CSS classes

## Root Cause

The `ExpansionPanel` wrapper defaulted to `expanded: false`. Any click within the `ExpansionPanelSummary` — including the Advanced Filters button — toggled the accordion rather than activating the button, creating both a UX bug and a test reliability issue.

## Dependencies

- Grievance E2E tests (`feature/coremis-e2e-grievance`) depend on this fix being merged first