### PR TITLE
improve error handling on Login

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -384,13 +384,28 @@ export function login(credentials) {
             {},
           ),
         );
+        if (response.payload?.response?.errors?.length > 0) {
+          const errorMessage = response.payload.response.errors[0].message;
+          dispatch(authError({ message: errorMessage }));
+          return { loginStatus: "CORE_AUTH_ERR", message: errorMessage };
+        }
+
         if (response.payload?.errors?.length > 0) {
           const errorMessage = response.payload.errors[0].message;
           dispatch(authError({ message: errorMessage }));
           return { loginStatus: "CORE_AUTH_ERR", message: errorMessage };
         }
 
-        const jwtToken = response.payload.data.tokenAuth.token;
+        const jwtToken = response.payload?.data?.tokenAuth?.token;
+        if (!response.payload?.data?.tokenAuth) {
+          if (response.payload?.message && response.payload.message !== "429 - Unknown Status") {
+            dispatch(authError({ message: response.payload.message }));
+            return { loginStatus: "CORE_AUTH_ERR", message: response.payload.message };
+          }
+          const message = "You have reached the maximum number of login attempts";
+          dispatch(authError({ message }));
+          return { loginStatus: "CORE_AUTH_ERR", message };
+        }
         const csrfResponse = await dispatch(fetchCsrfToken(jwtToken));
         const csrfToken = csrfResponse?.payload?.data?.getCsrfToken?.csrfToken;
         if (csrfToken) {


### PR DESCRIPTION
# Description

In Openimis, when you try to log in with invalid credentials, a bogus response appears that means nothing to the user. It's actually a JavaScript error instead of a login error. See the screenshot... so this ticket concerns fixing this JavaScript error and ensuring correct responses for the user.

<img width="529" height="848" alt="image" src="https://github.com/user-attachments/assets/82738457-7587-49fd-bdf7-47f0a7612175" />

We fixed the JavaScript errors and ensured that the execution path in the code now returns the correct feedback to the user during login attempts.

See screenshots...

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="529" height="848" alt="image" src="https://github.com/user-attachments/assets/41026a18-7f8f-40c3-8367-3e63d5b6d107" />
<img width="529" height="848" alt="Capture d’écran du 2026-03-18 14-06-11" src="https://github.com/user-attachments/assets/dc766b35-6951-4ee7-8d74-4441b20432cb" />
<img width="529" height="848" alt="Capture d’écran du 2026-03-18 14-06-28" src="https://github.com/user-attachments/assets/83deacc2-2dcc-4f42-8cec-cd5d3d72b87a" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
