### PR TITLE
Fix login error message [OP-2566]

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -377,7 +377,12 @@ export function login(credentials) {
           dispatch(authError({ message: errorMessage }));
           return { loginStatus: "CORE_AUTH_ERR", message: errorMessage };
         }
-        
+
+        if (!response.payload?.data?.tokenAuth) {
+          dispatch(authError({ message: "INCORRECT_CREDENTIALS" }));
+          return { loginStatus: "CORE_AUTH_ERR", message: "INCORRECT_CREDENTIALS" };
+        }
+
         const jwtToken = response.payload.data.tokenAuth.token;
         const csrfResponse = await dispatch(fetchCsrfToken(jwtToken));
         const csrfToken = csrfResponse?.payload?.data?.getCsrfToken?.csrfToken;


### PR DESCRIPTION
# Description

When an incorrect password is entered, the error message shows `cannot read properties of undefined (reading "tokenAuth")`. This PR fixes it and now it shows `The password or the username you've entered is incorrect.`

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2566

## Demo

<img width="1086" height="816" alt="image" src="https://github.com/user-attachments/assets/0facef4d-161a-4431-9d2d-42f5fb937bf1" />

## Checklist
- [x] Unit tests added/modified: this will make the currently failing auth E2E test pass
- [x] I18n / translation handled
