### PR TITLE
Bug fix: Integer numbers are formatted with decimals [OP-2988]

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,16 @@ Whenever the **individual** global schema changes (you add or remove a filter fi
 
   Note: depends on the selected calendar (Gregorian vs. Nepali)
 
+### Number Formatting
+
+`NumberInput` supports flexible decimal formatting:
+
+- **Auto-detection (default)**: When neither `numberOfDecimals` nor `allowDecimals` is specified, decimals are auto-detected from the value (integers display without decimals, decimal values preserve their precision)
+- **Fixed decimals**: Use `numberOfDecimals={N}` prop to enforce N decimal places
+- **Integer mode**: Use `allowDecimals={false}` prop to force integer-only input
+
+For monetary amounts that should always show decimals, `AmountInput` uses the global `fe-core.numberOfDecimals` config (default: 2).
+
 ### JSON handler
 
 - `createFieldsBasedOnJSON`: Creates additional fields from a JSON string and returns an array of field objects.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Whenever the **individual** global schema changes (you add or remove a filter fi
 - **Fixed decimals**: Use `numberOfDecimals={N}` prop to enforce N decimal places
 - **Integer mode**: Use `allowDecimals={false}` prop to force integer-only input
 
-For monetary amounts that should always show decimals, `AmountInput` uses the global `fe-core.numberOfDecimals` config (default: 2).
+Monetary amount decimal places can be controlled using the global `fe-core.numberOfDecimals` config (default: 2) or using the `numberOfDecimals` prop on `AmountInput` for individual input fields.
 
 ### JSON handler
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ Whenever the **individual** global schema changes (you add or remove a filter fi
     with config
     - `fe-core`, "thousandSeparator", "en"
     - `fe-core`, "numberOfDecimals", 2
-    - `fe-core`, "pricesAreDecimal", true
     the config thousandSeparator set the locale use by Intl.NumberFormat (e.g. "en") if you don't want formatting, set default value ""
     
 - `formatDateFromISO`: parse ISO date into (local) datetime

--- a/src/components/inputs/AmountInput.js
+++ b/src/components/inputs/AmountInput.js
@@ -4,9 +4,10 @@ import { InputAdornment } from "@material-ui/core";
 import NumberInput from "./NumberInput";
 import { useModulesManager } from "../../helpers/modules";
 
-const AmountInput = ({ intl, inputMinValue = 0, ...props }) => {
+const AmountInput = ({ intl, inputMinValue = 0, numberOfDecimals, ...props }) => {
   const modulesManager = useModulesManager();
   const position = modulesManager.getConf("fe-core", "AmountInput.currencyPosition", "start");
+  const defaultNumberOfDecimals = modulesManager.getConf("fe-core", "numberOfDecimals", 2);
 
   if (!["start", "end"].includes(position)) {
     throw new Error(`Position ${position} is not accepted. Only 'start' and 'end' are valid options.`);
@@ -17,6 +18,7 @@ const AmountInput = ({ intl, inputMinValue = 0, ...props }) => {
       <InputAdornment position={position}>{intl.formatMessage({ id: "currency" })}</InputAdornment>
     ),
     min: inputMinValue,
+    numberOfDecimals: numberOfDecimals ?? defaultNumberOfDecimals,
   };
 
   return <NumberInput {...props} {...extraProps} />;

--- a/src/components/inputs/FormattedNumberInput.js
+++ b/src/components/inputs/FormattedNumberInput.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import TextInput from "./TextInput";
 import { injectIntl } from "react-intl";
 import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
+import { getDecimalPlaces } from "../../helpers/utils";
 import { withModulesManager } from "@openimis/fe-core";
 
 class FormattedNumberInput extends Component {
@@ -27,9 +28,15 @@ class FormattedNumberInput extends Component {
 
   formatNumber = (value, intl) => {
     if (value == null || isNaN(value)) return "";
-    return new Intl.NumberFormat(this.props.thousandSeparator, {
-      minimumFractionDigits: this.props.numberOfDecimals,
-      maximumFractionDigits: this.props.numberOfDecimals,
+
+    const { numberOfDecimals, thousandSeparator } = this.props;
+    const decimals = numberOfDecimals !== undefined
+      ? numberOfDecimals
+      : getDecimalPlaces(value);
+
+    return new Intl.NumberFormat(thousandSeparator, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
     }).format(value);
   };
 

--- a/src/components/inputs/FormattedNumberInput.js
+++ b/src/components/inputs/FormattedNumberInput.js
@@ -30,9 +30,9 @@ class FormattedNumberInput extends Component {
     if (value == null || isNaN(value)) return "";
 
     const { numberOfDecimals, thousandSeparator } = this.props;
-    const decimals = numberOfDecimals !== undefined
-      ? numberOfDecimals
-      : getDecimalPlaces(value);
+    const decimals = numberOfDecimals === undefined
+      ? getDecimalPlaces(value)
+      : numberOfDecimals;
 
     return new Intl.NumberFormat(thousandSeparator, {
       minimumFractionDigits: decimals,

--- a/src/components/inputs/FormattedNumberInput.js
+++ b/src/components/inputs/FormattedNumberInput.js
@@ -28,14 +28,13 @@ class FormattedNumberInput extends Component {
   formatNumber = (value, intl) => {
     if (value == null || isNaN(value)) return "";
     return new Intl.NumberFormat(this.props.thousandSeparator, {
-      minimumFractionDigits: this.props.pricesAreDecimal ? this.props.numberOfDecimals : 0,
-      maximumFractionDigits: this.props.pricesAreDecimal ? this.props.numberOfDecimals : 0,
+      minimumFractionDigits: this.props.numberOfDecimals,
+      maximumFractionDigits: this.props.numberOfDecimals,
     }).format(value);
   };
 
   handleKeyPress = (event) => {
-    const { allowDecimals = true } = this.props;
-    if (event.key === "." && !allowDecimals) {
+    if (event.key === "." && this.props.numberOfDecimals === 0) {
       event.preventDefault();
     }
   };  
@@ -82,10 +81,8 @@ class FormattedNumberInput extends Component {
       min = null,
       max = null,
       error,
-      allowDecimals = true,
       thousandSeparator,
       numberOfDecimals,
-      pricesAreDecimal,
       ...others
     } = this.props;
 

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import TextInput from "./TextInput";
 import { injectIntl } from "react-intl";
 import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
+import { getDecimalPlaces } from "../../helpers/utils";
 import { withModulesManager } from "@openimis/fe-core";
 import FormattedNumberInput from "./FormattedNumberInput";
 
@@ -15,12 +16,13 @@ class NumberInput extends Component {
     this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "fr")
   }
 
-  getNumberOfDecimals = () => {
-    return this.props.numberOfDecimals ?? this.defaultNumberOfDecimals;
-  }
+  getEffectiveNumberOfDecimals = () => {
+    const { numberOfDecimals, allowDecimals = true } = this.props;
+    return !allowDecimals ? 0 : numberOfDecimals;
+  };
 
   handleKeyPress = (event) => {
-    if (event.key === "." && this.getNumberOfDecimals() === 0) {
+    if (event.key === "." && this.getEffectiveNumberOfDecimals() === 0) {
       event.preventDefault();
     }
   };
@@ -37,7 +39,11 @@ class NumberInput extends Component {
 
     if (isNaN(numericValue)) return "";
 
-    const decimals = this.getNumberOfDecimals();
+    const effectiveDecimals = this.getEffectiveNumberOfDecimals();
+    const decimals = effectiveDecimals !== undefined
+      ? effectiveDecimals
+      : getDecimalPlaces(numericValue);
+
     if (decimals > 0) {
       if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 0) {
         return parseFloat(value).toFixed(decimals);
@@ -87,15 +93,13 @@ class NumberInput extends Component {
         });
     }
 
-    const numberOfDecimals = this.getNumberOfDecimals();
-
     return (
       <>
         {!!this.thousandSeparator ? (
           <FormattedNumberInput
             {...this.props}
             thousandSeparator={this.thousandSeparator}
-            numberOfDecimals={numberOfDecimals}
+            numberOfDecimals={this.getEffectiveNumberOfDecimals()}
           />
         ) : (
           <TextInput

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -34,6 +34,13 @@ class NumberInput extends Component {
       return displayZero && value === 0 ? "0" : "";
     }
 
+    const strValue = String(value);
+
+    // Preserve raw string while user is mid-entry (e.g., "1.")
+    if (strValue.endsWith(".")) {
+      return value;
+    }
+
     const numericValue = Number(value);
 
     if (isNaN(numericValue)) return "";
@@ -44,7 +51,7 @@ class NumberInput extends Component {
       : getDecimalPlaces(numericValue);
 
     if (decimals > 0) {
-      if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 0) {
+      if (typeof value === "string" && strValue.includes(".") && strValue.split(".")[1].length > 0) {
         return parseFloat(value).toFixed(decimals);
       }
       return value;

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -12,7 +12,7 @@ class NumberInput extends Component {
     this.state = {
       isEdited: false,
     };
-    this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "fr")
+    this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "en")
   }
 
   getEffectiveNumberOfDecimals = () => {

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -11,20 +11,21 @@ class NumberInput extends Component {
     this.state = {
       isEdited: false,
     };
-    this.numberOfDecimals = props.modulesManager.getConf("fe-core", "numberOfDecimals", 2)
-    this.pricesAreDecimal = props.modulesManager.getConf("fe-core", "pricesAreDecimal", true)
+    this.defaultNumberOfDecimals = props.modulesManager.getConf("fe-core", "numberOfDecimals", 2)
     this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "fr")
   }
 
-  handleKeyPress = (event) => {
-    const { allowDecimals = true } = this.props;
+  getNumberOfDecimals = () => {
+    return this.props.numberOfDecimals ?? this.defaultNumberOfDecimals;
+  }
 
-    if (event.key === "." && !allowDecimals) {
+  handleKeyPress = (event) => {
+    if (event.key === "." && this.getNumberOfDecimals() === 0) {
       event.preventDefault();
     }
   };
 
-  formatInput = (value, displayZero, displayNa, decimal) => {
+  formatInput = (value, displayZero, displayNa) => {
     if (!value) {
       if (displayNa && !this.state.isEdited) {
         return formatMessage(this.props.intl, this.props.module, "core.NumberInput.notApplicable");
@@ -36,9 +37,10 @@ class NumberInput extends Component {
 
     if (isNaN(numericValue)) return "";
 
-    if (decimal) {
+    const decimals = this.getNumberOfDecimals();
+    if (decimals > 0) {
       if (typeof value === "string" && value.includes(".") && value.split(".")[1].length > 0) {
-        return parseFloat(value).toFixed(this.numberOfDecimals);
+        return parseFloat(value).toFixed(decimals);
       }
       return value;
     }
@@ -63,7 +65,6 @@ class NumberInput extends Component {
       error,
       displayZero = false,
       displayNa = false,
-      allowDecimals = this.pricesAreDecimal,
       ...others
     } = this.props;
     let inputProps = { ...this.props.inputProps, type: "number", onKeyPress: this.handleKeyPress };
@@ -86,14 +87,15 @@ class NumberInput extends Component {
         });
     }
 
+    const numberOfDecimals = this.getNumberOfDecimals();
+
     return (
       <>
         {!!this.thousandSeparator ? (
           <FormattedNumberInput
-            {...this.props} 
-            thousandSeparator = {this.thousandSeparator}
-            numberOfDecimals = {this.numberOfDecimals}
-            pricesAreDecimal = {this.pricesAreDecimal}
+            {...this.props}
+            thousandSeparator={this.thousandSeparator}
+            numberOfDecimals={numberOfDecimals}
           />
         ) : (
           <TextInput
@@ -102,14 +104,13 @@ class NumberInput extends Component {
             value={value}
             error={err}
             inputProps={inputProps}
-            formatInput={(v) => this.formatInput(v, displayZero, displayNa, allowDecimals)}
+            formatInput={(v) => this.formatInput(v, displayZero, displayNa)}
             onFocus={() => this.setState({ isEdited: true })}
             onBlur={() => this.handleNaBlur()}
           />
         )}
       </>
     );
-    
   }
 }
 

--- a/src/components/inputs/NumberInput.js
+++ b/src/components/inputs/NumberInput.js
@@ -12,13 +12,12 @@ class NumberInput extends Component {
     this.state = {
       isEdited: false,
     };
-    this.defaultNumberOfDecimals = props.modulesManager.getConf("fe-core", "numberOfDecimals", 2)
     this.thousandSeparator = props.modulesManager.getConf("fe-core", "thousandSeparator", "fr")
   }
 
   getEffectiveNumberOfDecimals = () => {
     const { numberOfDecimals, allowDecimals = true } = this.props;
-    return !allowDecimals ? 0 : numberOfDecimals;
+    return allowDecimals ? numberOfDecimals : 0;
   };
 
   handleKeyPress = (event) => {

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -36,7 +36,7 @@ export function formatAmount(mm, intl, amount) {
     return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
   }
 
-  const formattedAmount = parseFloat(amount).toFixed(numberOfDecimals);
+  const formattedAmount = Number(amount).toFixed(numberOfDecimals);
   return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
 }
 

--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -27,17 +27,16 @@ export function formatMessageWithValues(intl, module, id, values) {
 export function formatAmount(mm, intl, amount) {
   const thousandSeparator = mm.getConf("fe-core", "thousandSeparator", "en");
   const number = amount || 0;
-  const pricesAreDecimal = mm.getConf("fe-core", "pricesAreDecimal", true);
   const numberOfDecimals = mm.getConf("fe-core", "numberOfDecimals", 2);
   if (!!thousandSeparator) {
     const formattedAmount = new Intl.NumberFormat(thousandSeparator, {
-      minimumFractionDigits: pricesAreDecimal ? numberOfDecimals : 0,
-      maximumFractionDigits: pricesAreDecimal ? numberOfDecimals : 0,
+      minimumFractionDigits: numberOfDecimals,
+      maximumFractionDigits: numberOfDecimals,
     }).format(number);
     return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
-  } 
+  }
 
-  const formattedAmount = parseFloat(amount).toFixed(pricesAreDecimal ? numberOfDecimals : 0);
+  const formattedAmount = parseFloat(amount).toFixed(numberOfDecimals);
   return `${intl.formatMessage({ id: "currency" })} ${formattedAmount}`;
 }
 

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -61,8 +61,9 @@ export function isEmptyObject(obj) {
   return Object.keys(obj).length === 0;
 }
 
+// value is expected to be a number, not string
 export function getDecimalPlaces(value) {
-  if (value == null || isNaN(Number(value))) return 0;
+  if (value == null || Number.isNaN(Number(value))) return 0;
 
   const str = String(Number(value));
   if (!str.includes('.')) return 0;

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -61,6 +61,15 @@ export function isEmptyObject(obj) {
   return Object.keys(obj).length === 0;
 }
 
+export function getDecimalPlaces(value) {
+  if (value == null || isNaN(Number(value))) return 0;
+
+  const str = String(Number(value));
+  if (!str.includes('.')) return 0;
+  return str.split('.')[1]?.length || 0;
+}
+
+
 export function menuEntryMatchesLocationPath(entry) {
   const pathname = location.pathname
   return (


### PR DESCRIPTION
# Description

Fixes a bug where integer fields (number of beneficiaries, days, quantity, population, periodicity, etc.) were incorrectly displayed with 2 decimal places due to the global `numberOfDecimals` config being applied universally. Instead of requiring `allowDecimals={false}` on 40+ fields across the project, `NumberInput` now auto-detects decimal places from the value itself – integers display without decimals, decimal values preserve their precision – while AmountInput continues using the global config for monetary values that should always show decimals. 

Once merged to develop branch, this should fix some of the failing E2E tests.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2988

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [x] Existing E2E tests previously failing passed
- [x] I18n / translation handled
