### PR TITLE
fix display complex products sub-services & sub-items #OP-2998

### DIFF
--- a/src/components/generics/SearcherActionButton.js
+++ b/src/components/generics/SearcherActionButton.js
@@ -7,7 +7,7 @@ import { DEFAULT } from "../../constants";
 
 const SearcherActionButton = ({ onClick, startIcon, label }) => {
   const modulesManager = useModulesManager();
-  const isWorker = modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
+  const isWorker = !!modulesManager ? modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER) : DEFAULT.IS_WORKER;
 
   return (
     <Button variant="outlined" style={{ border: 0 }} onClick={onClick} startIcon={startIcon}>

--- a/src/components/generics/SearcherActionButton.js
+++ b/src/components/generics/SearcherActionButton.js
@@ -7,7 +7,7 @@ import { DEFAULT } from "../../constants";
 
 const SearcherActionButton = ({ onClick, startIcon, label }) => {
   const modulesManager = useModulesManager();
-  const isWorker = !!modulesManager ? modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER) : DEFAULT.IS_WORKER;
+  const isWorker = modulesManager.getConf("fe-core", "isWorker", DEFAULT.IS_WORKER);
 
   return (
     <Button variant="outlined" style={{ border: 0 }} onClick={onClick} startIcon={startIcon}>

--- a/src/components/generics/TableService.js
+++ b/src/components/generics/TableService.js
@@ -269,10 +269,10 @@ class Table extends Component {
                             })}
                         </tr>
                       </table>
-                      {localItemFormatters[0](i, iidx).props.children.props.value != undefined &&
+                      {localItemFormatters[0](i, iidx).props.children.props.children.props.value != undefined &&
                         (
-                          localItemFormatters[0](i, iidx).props.children.props.value.packagetype != undefined &&
-                          localItemFormatters[0](i, iidx).props.children.props.value.packagetype !== "S" && (
+                          localItemFormatters[0](i, iidx).props.children.props.children.props.value.packagetype != undefined &&
+                          localItemFormatters[0](i, iidx).props.children.props.children.props.value.packagetype !== "S" && (
 
                             <table style={{ marginTop: 10, width: "90%" }}>
                               <tr>

--- a/src/components/generics/TableService.js
+++ b/src/components/generics/TableService.js
@@ -331,10 +331,10 @@ class Table extends Component {
                             })}
                         </tr>
                       </table>
-                      {localItemFormatters[0](i, iidx).props.children.props.value != undefined &&
+                      {localItemFormatters[0](i, iidx).props.children.props.children.props.value != undefined &&
                         (
-                          localItemFormatters[0](i, iidx).props.children.props.value.packagetype != undefined &&
-                          localItemFormatters[0](i, iidx).props.children.props.value.packagetype !== "S" && (
+                          localItemFormatters[0](i, iidx).props.children.props.children.props.value.packagetype != undefined &&
+                          localItemFormatters[0](i, iidx).props.children.props.children.props.value.packagetype !== "S" && (
 
                             <table style={{ marginTop: 10, width: "90%" }}>
                               <tr>

--- a/src/pages/Help.js
+++ b/src/pages/Help.js
@@ -18,7 +18,7 @@ const styles = (theme) => ({
 const Help = ({ classes }) => {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
-  const isCoreMISHelp = !!modulesManager ? modulesManager.getConf("fe-core", "redirectToCoreMISConfluenceUrl", false): false;
+  const isCoreMISHelp = modulesManager.getConf("fe-core", "redirectToCoreMISConfluenceUrl", false);
   const url = isCoreMISHelp ? CORE_MIS_CONFLUENCE_URL : DEFAULT_URL;
   const onClick = () => {
     window.open(url);

--- a/src/pages/Help.js
+++ b/src/pages/Help.js
@@ -18,7 +18,7 @@ const styles = (theme) => ({
 const Help = ({ classes }) => {
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
-  const isCoreMISHelp = modulesManager.getConf("fe-core", "redirectToCoreMISConfluenceUrl", false);
+  const isCoreMISHelp = !!modulesManager ? modulesManager.getConf("fe-core", "redirectToCoreMISConfluenceUrl", false): false;
   const url = isCoreMISHelp ? CORE_MIS_CONFLUENCE_URL : DEFAULT_URL;
   const onClick = () => {
     window.open(url);


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

When entering a claim, selecting a complex service does not display its associated sub-services and sub-items. To solve that i have adjust the TableService.js component to fetch seleected service.
I encountered  and fix additional bugs when installing the module locally in the Help.js and SearcherActionButton.js

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/0d30a15b-d845-4ede-8245-cb31470eed65



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
