### PR TITLE
fix: bind modulesManager on formatAmount function

### DIFF
--- a/src/helpers/i18n.js
+++ b/src/helpers/i18n.js
@@ -81,7 +81,7 @@ export function useTranslations(moduleName, modulesManager) {
   return {
     formatDateFromISO: formatDateFromISO.bind(null, modulesManager, intl),
     formatDateTimeFromISO: formatDateTimeFromISO.bind(null, modulesManager, intl),
-    formatAmount: formatAmount.bind(null, intl),
+    formatAmount: formatAmount.bind(null, modulesManager, intl),
     formatMessage: moduleName ? formatMessage.bind(null, intl, moduleName) : formatMessage.bind(null, intl),
     formatMessageWithValues: moduleName
       ? formatMessageWithValues.bind(null, intl, moduleName)


### PR DESCRIPTION
# Description

Fixes binding of the modules manager on the formatAmount function in i18n helpers. 

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [x] I18n / translation handled
