### PR TITLE
fix(core): coreConfirm intent handling OP-3018

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -133,9 +133,7 @@ const App = (props) => {
   }, [isSecondaryCalendar]);
 
   useEffect(() => {
-    if (confirm?.intent) {
-      setLastConfirmIntent(confirm.intent);
-    }
+    setLastConfirmIntent(confirm?.intent ?? null);
   }, [confirm]);
 
   useEffect(() => {


### PR DESCRIPTION
# Description

(Release) When a user has been previously logged out due to session expiration, the logout intent remains in the app's state, causing the user to be systematically logged out when they confirm the coreConfirm for another action within the app, such as deleting an Individual or a BenefitPlan. We have therefore fixed this by ensuring that the intent is cleaned up when necessary.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
