### PR TITLE
fix(table): render pagination footer at full width and remove flex footer layout

### DIFF
--- a/src/components/generics/Table.jsx
+++ b/src/components/generics/Table.jsx
@@ -79,12 +79,24 @@ const StyledTable = styled("div")(({ theme }) => ({
     right: 0,
     background: "rgba(0, 0, 0, 0.12)",
   },
+  "& .paginationWrapper": {
+    display: "flex",
+    justifyContent: "flex-start",
+    alignItems: "center",
+    width: "100%",
+  },
+  "& .lockControl": {
+    display: "flex",
+    alignItems: "center",
+    marginRight: theme.spacing(2),
+  },
 }));
 
 class Table extends Component {
   state = {
     selection: {},
     isRowsPerPageLocked: false,
+    ordinalNumberFrom: null,
   };
 
   _atom = (a) =>
@@ -153,7 +165,6 @@ class Table extends Component {
   isSelected = (i) => !!this.props.withSelection && !!this.state.selection[this.itemIdentifier(i)];
 
   select = (i, e) => {
-    // block normal href only for left click
     if (e.type === "click" || this.props.selectWithCheckbox) {
       if (!this.props.withSelection) return;
       let s = this.state.selection;
@@ -283,6 +294,7 @@ class Table extends Component {
     if (showOrdinalNumber) {
       localHeaders.unshift("core.Table.ordinalNumberHeader");
     }
+
     return (
       <StyledTable>
         <Box position="relative" overflow="auto">
@@ -414,8 +426,6 @@ class Table extends Component {
                     {localItemFormatters &&
                       localItemFormatters.map((f, fidx) => {
                         if (colSpans.length > fidx && !colSpans[fidx]) return null;
-                        // NOTE: The 'f' function can explicitly be set to null, enabling the option to omit
-                        // a column  and suppress its display under specific conditions.
                         if (f === null) return null;
                         return (
                           <TableCell
@@ -443,8 +453,8 @@ class Table extends Component {
               <TableFooter className="tableFooter">
                 <TableRow>
                   <TableCell colSpan={localItemFormatters.length + (selectWithCheckbox ? 1 : 0)}>
-                    <Box display="flex" justifyContent="flex-end" alignItems="center" width="100%">
-                      <Box display="flex" justifyContent="flex-end" alignItems="center">
+                    <Box className="paginationWrapper">
+                      <Box className="lockControl">
                         <Tooltip title={formatMessage(intl, "core", "Table.lockRowsPerPage.tooltip")}>
                           <Checkbox checked={this.state.isRowsPerPageLocked} onChange={this.onToggleRowsPerPageLock} />
                         </Tooltip>
@@ -476,8 +486,7 @@ class Table extends Component {
           </MUITable>
           {(fetching || error) && (
             <Grid className="loader" container justifyContent="center" alignItems="center">
-              <ProgressOrError progress={items?.length && fetching} error={error} />{" "}
-              {/* We do not want to display the spinner with the empty table */}
+              <ProgressOrError progress={items?.length && fetching} error={error} />
             </Grid>
           )}
         </Box>
@@ -487,6 +496,7 @@ class Table extends Component {
 }
 
 export { StyledTable };
+
 const mapStateToProps = (state) => ({
   user: state.core?.user,
 });


### PR DESCRIPTION
# Description

Critical: the pagination block has been partially hidden in the UI since the latest release, as shown in the screenshot below. This issue prevents users from properly performing certain actions in the UI and negatively impacts the user experience.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="957" height="256" alt="Capture d’écran du 2026-05-18 18-28-45" src="https://github.com/user-attachments/assets/078d099c-5405-4fb8-a0fe-fce6d506349b" />
<img width="957" height="256" alt="Capture d’écran du 2026-05-18 18-29-37" src="https://github.com/user-attachments/assets/3cca96eb-9a75-4261-ad5c-72821a1da0ab" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
