### PR TITLE
fix(core): preserve mutation immutability in journal and API state updates

### DIFF
--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -81,8 +81,9 @@ export function resetCacheFilters(key) {
 
 export function journalize(mutation, meta) {
   return (dispatch) => {
-    mutation.status = 0;
-    dispatch({ type: "CORE_MUTATION_ADD", payload: mutation, meta });
+    const mut = { ...mutation };
+    mut.status = 0;
+    dispatch({ type: "CORE_MUTATION_ADD", payload: mut, meta });
   };
 }
 

--- a/src/helpers/api.jsx
+++ b/src/helpers/api.jsx
@@ -128,17 +128,18 @@ export function dispatchMutationReq(state, action) {
   return {
     ...state,
     submittingMutation: true,
-    mutation: action.meta,
+    mutation: { ...action.meta },
   };
 }
 
 export function dispatchMutationResp(state, service, action) {
-  var mutation = state.mutation;
-  mutation.id = action.payload.data[service].internalId;
   return {
     ...state,
     submittingMutation: false,
-    mutation,
+    mutation: {
+      ...state.mutation,
+      id: action.payload?.data?.[service]?.internalId,
+    },
   };
 }
 


### PR DESCRIPTION
# Description

In Openimis Vite version, when trying to create or update an insuree, a family, a claim, etc., mutations across multiple modules cause the web application to crash.
This is due to an immutability issue when mutating the state

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
