### PR TITLE
ajust searcher header button & label style

### DIFF
--- a/src/components/generics/Searcher.jsx
+++ b/src/components/generics/Searcher.jsx
@@ -79,6 +79,7 @@ const StyledSearcher = styled("div")(({ theme }) => ({
   "& .paperHeaderMessage": {
     ...theme.paper?.message,
     backgroundColor: "transparent",
+    whiteSpace: "nowrap",
   },
   "& .paperHeaderAction": {
     ...theme.paper?.action,
@@ -106,6 +107,9 @@ const StyledSearcher = styled("div")(({ theme }) => ({
     overflow: "auto",
     display: "flex",
     flexDirection: "column",
+    "& button": {
+      whiteSpace: "nowrap",
+    },
   },
   "& .infoSection": {
     display: "flex",


### PR DESCRIPTION
# Description

The labels in the Searcher panel automatically wrap onto a new line even though there is sufficient space available in the container.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1333" height="149" alt="Screenshot 2026-06-19 at 4 15 42 PM" src="https://github.com/user-attachments/assets/15a32851-9d1b-4fb0-9729-3190fafacceb" />
<img width="1351" height="138" alt="Screenshot 2026-06-19 at 5 00 48 PM" src="https://github.com/user-attachments/assets/6ed56a93-f5e5-47d7-8040-c11e40d7a111" />
<img width="1336" height="122" alt="Screenshot 2026-06-19 at 5 00 58 PM" src="https://github.com/user-attachments/assets/bdf63f79-3306-4fec-9d2b-177ce07ca970" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
