### PR TITLE
Feature/config input style - OP-3079

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# Agents Guidelines for openIMIS Core Frontend
+
+## Theming and Color Usage (Important for Consistency)
+
+All form inputs (TextInput, SelectInput, DatePicker, Autocomplete, Picker, etc.) ultimately rely on MUI's `TextField` (or equivalent) for rendering labels and input text.
+
+**Rule:** Prefer the color scheme provided by the MUI theme over component-local overrides.
+
+- **Do not force label colors.** Remove or avoid rules like:
+  ```js
+  '& .label': {
+    color: theme.palette.primary.main,
+  }
+  ```
+  These cause labels (and sometimes related text) on datepickers, selects/dropdowns, and custom pickers to differ from standard input text or other fields' labels.
+
+- Let MUI + the host application's theme control `InputLabel` and input text colors. Apps commonly customize via:
+  - `theme.palette.text.primary` / `theme.palette.text.secondary`
+  - `theme.components.MuiInputLabel.styleOverrides`
+  - `theme.components.MuiOutlinedInput` / `MuiInput` etc.
+  - `theme.typography`
+
+- **Always derive colors from `theme`** (passed to `styled()` callbacks or `useTheme()`):
+  - Input / value text: `theme.palette.text.primary`
+  - Labels / secondary text: `theme.palette.text.secondary`
+  - Errors: `theme.palette.error.main`
+  - Primary actions: `theme.palette.primary.main`
+  - Disabled / placeholders: `theme.palette.text.disabled`, `theme.palette.action.disabled`, `theme.palette.divider`
+
+- **Main / secondary palette colors and UI surfaces**: `theme.palette.primary.main`, `theme.palette.secondary.main`, `theme.palette.primary.light`, etc. are the right source for brand accent colors, active states, call-to-action elements, and certain highlights.
+  - However, for structural / container elements (page shells, paper cards, form sections, table headers/rows, menu drawers, headers, FABs, dialogs, journal items, etc.) **strongly prefer the dedicated theme extension objects** first:
+    - `theme.paper` (`.paper`, `.header`, `.title`, `.item`, `.action`, `.paperHeader` ...)
+    - `theme.page` (and `.locked` etc.)
+    - `theme.menu` (`.drawer.*`, `.appBar.*`, `.variant`)
+    - `theme.table` (`.header`, `.row`, `.highlightedRow`, `.title` ...)
+    - `theme.fab`, `theme.dialog`, `theme.jrnlDrawer`, `theme.fakeInput`, etc.
+  - Common safe pattern (allows full override while providing a fallback):
+    ```js
+    color: theme.paper?.header?.color || theme.palette.primary.main,
+    backgroundColor: theme.paper?.header?.backgroundColor || theme.palette.primary.light,
+    ...theme.paper?.header,
+    ```
+  - Direct `primary.main` / `secondary.main` usage is appropriate for interactive accents, but surfaces and layout colors should be overridable via the higher-level theme keys so consuming applications can define a complete, coherent color scheme.
+
+- **Never use hardcoded hex/rgb colors** (except as last-resort fallbacks inside theme expressions like `?? theme.palette.background.default`). They break theming and dark mode support. Update any that remain.
+
+- For custom non-MUI controls (e.g. `react-multi-date-picker` in secondary calendar mode, or `react-multi-date-picker`):
+  - Explicitly apply `theme.palette.text.primary` (for values) and `theme.palette.text.secondary` (for labels) inside the `styled` wrapper.
+
+- Disabled / read-only "visibility boost" styles must still pull from the theme (see examples in TextInput.jsx and DatePicker.jsx).
+
+- FieldLabel uses `...theme.typography?.label ?? {}` — extend via theme if custom label typography/color is needed.
+
+### Why this matters
+Previously, several input wrappers overrode labels to `primary.main`. Direct use of `palette.primary.main` / `secondary.main` for headers, papers, and containers (without theme.* fallbacks) also led to inconsistency.
+
+This created slight but noticeable color differences:
+- Between regular TextInput labels and DatePicker / Autocomplete / Picker labels
+- Between dropdown (SelectInput) labels (which did *not* override) and other inputs
+- Between MUI-based fields and custom date pickers
+- Between modules that used `theme.paper.header` (or similar) vs. those that hard-baked primary/secondary for the same surfaces
+
+Removing per-component overrides + preferring dedicated theme sections (paper, menu, table, ...) + falling back to palette colors only when needed ensures that the host app's full color scheme (including its chosen primary/secondary values or entirely custom surfaces) is respected everywhere.
+
+## General
+
+- This is the `@openimis/fe-core` package. Changes here affect all openIMIS frontend modules.
+- Use MUI v7+ components and `@mui/material/styles` `styled()`.
+- Input variant (standard/outlined/filled) is configurable via modules manager: `Input.variant`.
+- When adding new inputs or pickers, wrap with `styled()` using the theme callback and inherit MUI TextField where possible.
+- Update this file when introducing new theming or styling conventions.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
   "engines": {
-    "node": ">=8",
-    "npm": ">=5"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "scripts": {
     "build": "vite build",
@@ -17,52 +17,40 @@
     "prepare": "npm run build"
   },
   "peerDependencies": {
+    "@emotion/react": "^11.11.4",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^7.2.0",
+    "@mui/material": "^7.2.0",
+    "@mui/x-date-pickers": "^8.9.0",
+    "@sentry/react": "^10.17.0",
+    "clsx": "^2.0.0",
+    "dayjs": "^1.11.13",
+    "history": "^5.2.0",
+    "lodash": "^4.17.21",
+    "lodash-uuid": "^0.0.3",
+    "moment": "^2.25.3",
+    "nepali-date-converter": "^3.3.1",
+    "prop-types": "^15.7.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-intl": "^7.1.11",
-    "@emotion/react": "^11.11.4",
-    "@emotion/styled": "^11.11.0",
-    "@mui/material": "^7.2.0",
-    "@mui/icons-material": "^7.2.0",
-    "@mui/x-date-pickers": "^8.9.0",
-    "dayjs": "^1.11.13",
+    "react-multi-date-picker": "^4.5.2",
+    "react-redux": "^8.0.0 || ^9.0.0",
+    "react-router": "^5.2.1",
+    "react-router-dom": "^5.2.1",
     "redux": "^5.0.1",
-    "moment": "^2.25.3",
-    "react-multi-date-picker": "^4.5.2"
+    "redux-api-middleware": "^3.2.1",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.9.6",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
-    "@babel/plugin-transform-runtime": "^7.9.6",
-    "@babel/preset-env": "^7.9.6",
-    "@babel/preset-react": "^7.9.4",
-    "@babel/runtime": "^7.9.6",
-    "@sentry/react": "^10.17.0",
     "@vitejs/plugin-react": "^5.0.0",
-    "history": "^5.2.0",
-    "lodash-uuid": "^0.0.3",
     "prettier": "^2.3.2",
-    "prop-types": "^15.7.2",
-    "react-autosuggest": "^10.0.2",
-    "react-date-object": "^1.3.10",
-    "redux-api-middleware": "^3.2.1",
     "vite": "^7.3.1",
     "vite-plugin-svgr": "^4.3.0"
   },
   "files": [
     "dist",
     "src"
-  ],
-  "dependencies": {
-    "history": "^5.2.0",
-    "nepali-date-converter": "^3.3.1",
-    "react-multi-date-picker": "^4.3.3",
-    "react-router": "^5.2.1",
-    "react-router-dom": "^5.2.1",
-    "zxcvbn": "^4.4.2"
-  }
+  ]
 }

--- a/src/admin/components/EnrolmentVillagesPicker.jsx
+++ b/src/admin/components/EnrolmentVillagesPicker.jsx
@@ -174,7 +174,7 @@ const EnrolmentVillagesPicker = (props) => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <ProgressOrError progress={fetchingDistrictMunAndVil} error={errorDistrictMunAndVil} />
+          <ProgressOrError progress={fetchingDistrictMunAndVil} error={errorDistrictMunAndVil} colSpan={3} />
           {items.map((item, idx) => (
             <TableRow key={item.parent?.id ?? `row-${idx}`}>
               <TableCell>
@@ -216,15 +216,19 @@ const EnrolmentVillagesPicker = (props) => {
           ))}
         </TableBody>
         <TableFooter>
-          <Button
-            disabled={readOnly}
-            variant="contained"
-            onClick={onInsertRow}
-            startIcon={<AddIcon />}
-            className="footer"
-          >
-            {formatMessage("table.newRow")}
-          </Button>
+          <TableRow>
+            <TableCell colSpan={3}>
+              <Button
+                disabled={readOnly}
+                variant="contained"
+                onClick={onInsertRow}
+                startIcon={<AddIcon />}
+                className="footer"
+              >
+                {formatMessage("table.newRow")}
+              </Button>
+            </TableCell>
+          </TableRow>
         </TableFooter>
       </Table>
     </StyledTableContainer>

--- a/src/components/dialogs/AdvancedFilterRowValue.jsx
+++ b/src/components/dialogs/AdvancedFilterRowValue.jsx
@@ -20,7 +20,7 @@ import {
 
 const StyledGrid = styled(Grid)(({ theme }) => ({
   '& .item': theme.paper?.item ?? {},
-  backgroundColor: theme.paper?.paper?.backgroundColor ?? "#dbeef0",
+  backgroundColor: theme.paper?.paper?.backgroundColor ?? theme.palette.background.default,
   '& .removeIcon': {
     transform: 'translate(-50%, -50%)',
     fontSize: '16px',
@@ -28,7 +28,7 @@ const StyledGrid = styled(Grid)(({ theme }) => ({
     cursor: 'pointer',
   },
   '& .removeIconContainer': {
-    backgroundColor: theme.paper?.paper?.backgroundColor ?? "#dbeef0",
+    backgroundColor: theme.paper?.paper?.backgroundColor ?? theme.palette.background.default,
     width: '25px',
     height: '25px',
     marginTop: '25px',

--- a/src/components/dialogs/AdvancedFiltersDialog.jsx
+++ b/src/components/dialogs/AdvancedFiltersDialog.jsx
@@ -8,7 +8,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Grid from "@mui/material/Grid";
 import { formatMessage } from "../../helpers/i18n";
 import SearcherActionButton from "../generics/SearcherActionButton";
-import { styled } from "@mui/material/styles";
+import { styled, useTheme } from "@mui/material/styles";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import AdvancedFilterRowValue from "./AdvancedFilterRowValue";
@@ -49,6 +49,7 @@ const AdvancedFiltersDialog = ({
   const [isOpen, setIsOpen] = useState(false);
   const [currentFilter, setCurrentFilter] = useState({ field: "", filter: "", type: "", value: "" });
   const [filters, setFilters] = useState([currentFilter]);
+  const theme = useTheme();
 
   const searchCriteriaToArray = () => {
     return hasCustomFilters()
@@ -217,7 +218,7 @@ const AdvancedFiltersDialog = ({
               />
             );
           })}
-          <div style={{ backgroundColor: "#DFEDEF", paddingLeft: "10px", paddingBottom: "10px" }}>
+          <div style={{ backgroundColor: theme.palette.background.default, paddingLeft: "10px", paddingBottom: "10px" }}>
             <AddCircle
               style={{
                 border: "thin solid",

--- a/src/components/generics/Picker.jsx
+++ b/src/components/generics/Picker.jsx
@@ -128,6 +128,22 @@ class Picker extends Component {
 
   renderIcon() {
     const { IconRender, title } = this.props;
+    if (React.isValidElement(IconRender)) {
+      const elType = IconRender.type;
+      const typeName = (typeof elType === "string" ? elType : elType && (elType.displayName || elType.name)) || "";
+      if (/button/i.test(typeName)) {
+        return React.cloneElement(IconRender, { title, onClick: this.onClick });
+      }
+      return (
+        <IconButton title={title} onClick={this.onClick}>
+          {IconRender}
+        </IconButton>
+      );
+    }
+    const compName = (IconRender && (IconRender.displayName || IconRender.name)) || "";
+    if (/button/i.test(compName)) {
+      return <IconRender title={title} onClick={this.onClick} />;
+    }
     return (
       <IconButton title={title} onClick={this.onClick}>
         <IconRender />

--- a/src/components/generics/Picker.jsx
+++ b/src/components/generics/Picker.jsx
@@ -23,9 +23,6 @@ import Table from "./Table";
 import FakeInput from "../inputs/FakeInput";
 
 const StyledPicker = styled('div')(({ theme }) => ({
-  '& .label': {
-    color: theme.palette.primary.main,
-  },
   '& .dialogTitle': theme?.dialog?.title ?? {},
   '& .dialogContent': theme?.dialog?.content ?? {},
 }));
@@ -149,9 +146,6 @@ class Picker extends Component {
           label={!!label && formatMessage(intl, module, label)}
           onClick={(e) => this.setState({ open: true })}
           value={suggestionFormatter(value)}
-          InputLabelProps={{
-            className: "label",
-          }}
           InputProps={{
             startAdornment: !readOnly && (
               <InputAdornment position="start">

--- a/src/components/generics/Table.jsx
+++ b/src/components/generics/Table.jsx
@@ -5,7 +5,7 @@ import _ from "lodash";
 import GetIconComponent from "../../helpers/icons";
 
 const DeleteIcon = GetIconComponent("Delete")
-import { styled, alpha } from "@mui/material/styles";
+import { styled } from "@mui/material/styles";
 import {
   Typography,
   Divider,
@@ -33,10 +33,10 @@ const StyledTable = styled("div")(({ theme }) => ({
   },
   "& .MuiTableCell-root": {
     padding: theme.spacing(0.5, 1),
-    borderColor: alpha(theme.palette.primary.main, 0.1),
+    borderColor: theme.palette.divider,
   },
   "& .MuiTableRow-root:hover": {
-    backgroundColor: alpha(theme.palette.primary.main, 0.05),
+    backgroundColor: theme.palette.action.hover,
   },
   "& .tableTitle": {
     ...theme.table?.title,

--- a/src/components/inputs/AutoSuggestion.jsx
+++ b/src/components/inputs/AutoSuggestion.jsx
@@ -10,6 +10,7 @@ const SearchIcon = GetIconComponent("Search")
 import withModulesManager from "../../helpers/modules";
 import { injectIntl } from "react-intl";
 import _ from "lodash";
+import { DEFAULT } from "../../constants";
 
 const StyledAutoSuggestion = styled("div")(({ theme }) => ({
   "& .paper": {
@@ -71,6 +72,11 @@ class AutoSuggestion extends Component {
   constructor(props) {
     super(props);
     this.limitDisplay = props.modulesManager.getConf("fe-core", "AutoSuggestion.limitDisplay", 10);
+    this.inputVariant = props.modulesManager.getConf(
+      "fe-core",
+      "Input.variant",
+      DEFAULT.INPUT_VARIANT,
+    );
   }
 
   state = INIT_STATE;
@@ -183,9 +189,10 @@ class AutoSuggestion extends Component {
   renderInputComponent = ({ inputRef, ...inputProps }) => {
     const { label } = this.props;
     return (
-      <FormControl fullWidth>
+      <FormControl fullWidth variant={this.inputVariant}>
         <TextField
           {...inputProps}
+          variant={this.inputVariant}
           label={label}
           InputLabelProps={{
             ...inputProps.InputLabelProps,
@@ -322,7 +329,7 @@ class AutoSuggestion extends Component {
     if (readOnly) {
       return (
         <StyledAutoSuggestion>
-          <TextField label={label} className="textField" disabled value={value || ""} title={title} />
+          <TextField variant={this.inputVariant} label={label} className="textField" disabled value={value || ""} title={title} />
         </StyledAutoSuggestion>
       );
     }

--- a/src/components/inputs/AutoSuggestion.jsx
+++ b/src/components/inputs/AutoSuggestion.jsx
@@ -23,9 +23,6 @@ const StyledAutoSuggestion = styled("div")(({ theme }) => ({
     backgroundColor: theme.palette.grey[100],
     padding: theme.spacing(1),
   },
-  "& .label": {
-    color: theme.palette.primary.main,
-  },
   "& .textField": {
     width: "100%",
     minWidth: "120px",
@@ -194,10 +191,7 @@ class AutoSuggestion extends Component {
           {...inputProps}
           variant={this.inputVariant}
           label={label}
-          InputLabelProps={{
-            ...inputProps.InputLabelProps,
-            className: "label",
-          }}
+          InputLabelProps={inputProps.InputLabelProps}
           inputRef={inputRef}
           InputProps={{
             ...inputProps.InputProps,

--- a/src/components/inputs/Autocomplete.jsx
+++ b/src/components/inputs/Autocomplete.jsx
@@ -8,9 +8,6 @@ import { useModulesManager } from "../../helpers/modules";
 import { DEFAULT } from "../../constants";
 
 const StyledAutocomplete = styled('div')(({ theme }) => ({
-  '& .label': {
-    color: theme.palette.primary.main,
-  },
   '& .MuiAutocomplete-root': {
     minWidth: '150px',
     width: "100%",
@@ -123,7 +120,7 @@ const Autocomplete = (props) => {
                   {...inputProps}
                   variant={inputVariant}
                   required={required}
-                  InputLabelProps={{ shrink: value !== undefined, className: "label" }}
+                  InputLabelProps={{ shrink: value !== undefined }}
                   label={withLabel && (label || formatMessage("label"))}
                   placeholder={!readOnly && withPlaceholder ? (placeholder || formatMessage("placeholder")) : undefined}
                 />

--- a/src/components/inputs/Autocomplete.jsx
+++ b/src/components/inputs/Autocomplete.jsx
@@ -5,6 +5,7 @@ import { TextField } from "@mui/material";
 import { useDebounceCb } from "../../helpers/hooks";
 import { useTranslations } from "../../helpers/i18n";
 import { useModulesManager } from "../../helpers/modules";
+import { DEFAULT } from "../../constants";
 
 const StyledAutocomplete = styled('div')(({ theme }) => ({
   '& .label': {
@@ -51,6 +52,11 @@ const Autocomplete = (props) => {
   } = props;
   const modulesManager = useModulesManager();
   const minCharLookup = modulesManager.getConf("fe-admin", "usersMinCharLookup", 2);
+  const inputVariant = modulesManager.getConf(
+    "fe-core",
+    "Input.variant",
+    DEFAULT.INPUT_VARIANT,
+  );
   const { formatMessage } = useTranslations("core.Autocomplete", modulesManager);
   const [open, setOpen] = useState(false);
   const [resetKey, setResetKey] = useState(Date.now());
@@ -115,6 +121,7 @@ const Autocomplete = (props) => {
             : (inputProps) => (
                 <TextField
                   {...inputProps}
+                  variant={inputVariant}
                   required={required}
                   InputLabelProps={{ shrink: value !== undefined, className: "label" }}
                   label={withLabel && (label || formatMessage("label"))}

--- a/src/components/inputs/SelectInput.jsx
+++ b/src/components/inputs/SelectInput.jsx
@@ -10,6 +10,8 @@ const ClearIcon = GetIconComponent("Clear")
 import FormattedMessage from "../generics/FormattedMessage";
 import TextInput from "./TextInput";
 import { formatMessage } from "../../helpers/i18n";
+import withModulesManager from "../../helpers/modules";
+import { DEFAULT } from "../../constants";
 
 const StyledSelectInput = styled("div")(({ theme }) => ({
   "& .formControl": {
@@ -35,6 +37,11 @@ class SelectInput extends Component {
   constructor(props) {
     super(props);
     this.uuid = props.name || _.uuid();
+    this.inputVariant = props.modulesManager.getConf(
+      "fe-core",
+      "Input.variant",
+      DEFAULT.INPUT_VARIANT,
+    );
   }
 
   _onChange = (e) => {
@@ -96,6 +103,7 @@ class SelectInput extends Component {
           {!readOnly && (
             <TextField
               select
+              variant={this.props.variant || this.inputVariant}
               fullWidth
               required={required}
               disabled={disabled}
@@ -156,4 +164,4 @@ class SelectInput extends Component {
 }
 
 export { StyledSelectInput };
-export default injectIntl(SelectInput);
+export default withModulesManager(injectIntl(SelectInput));

--- a/src/components/inputs/TextInput.jsx
+++ b/src/components/inputs/TextInput.jsx
@@ -46,6 +46,11 @@ class TextInput extends Component {
       "Input.disabledVisibilityBoost",
       DEFAULT.DISABLED_VISIBILITY_BOOST,
     );
+    this.inputVariant = props.modulesManager.getConf(
+      "fe-core",
+      "Input.variant",
+      DEFAULT.INPUT_VARIANT,
+    );
   }
 
   state = {
@@ -99,6 +104,7 @@ class TextInput extends Component {
     return (
       <StyledTextInput>
         <TextField
+          variant={this.inputVariant}
           {...others}
           className={clsx({
             "numberInput": true,

--- a/src/components/inputs/TextInput.jsx
+++ b/src/components/inputs/TextInput.jsx
@@ -8,9 +8,6 @@ import { DEFAULT } from "../../constants";
 import withModulesManager from "../../helpers/modules";
 
 const StyledTextInput = styled('div')(({ theme }) => ({
-  '& .label': {
-    color: theme.palette.primary.main,
-  },
   // NOTE: This is used to hide the increment/decrement arrows from the number input
   '& .numberInput': {
     "& input[type=number]": {
@@ -27,13 +24,13 @@ const StyledTextInput = styled('div')(({ theme }) => ({
   },
   '& .disabledStateVisibilityBoost': {
     "& .Mui-disabled": {
-      color: '#5E5B50',
+      color: theme.palette.text.primary,
     },
     "& .MuiInput-underline:before": {
-      borderBottom: `1px dotted #5E5B50`,
+      borderBottom: `1px dotted ${theme.palette.text.disabled || theme.palette.divider}`,
     },
     "& .MuiFormLabel-root.Mui-disabled": {
-      color: "#181716",
+      color: theme.palette.text.secondary,
     }
   },
 }));
@@ -113,9 +110,6 @@ class TextInput extends Component {
           fullWidth
           disabled={readOnly}
           label={!!label && formatMessage(intl, module, label)}
-          InputLabelProps={{
-            className: "label",
-          }}
           InputProps={{ inputProps, startAdornment, endAdornment }}
           onChange={this._onChange}
           value={this.state.value}

--- a/src/constants.js
+++ b/src/constants.js
@@ -133,6 +133,7 @@ export const DEFAULT = {
   ENABLE_PUBLIC_PAGE: false,
   SHOW_JOURNAL_SIDEBAR: true,
   DISABLED_VISIBILITY_BOOST: false,
+  INPUT_VARIANT: "standard",
 }
 
 export const EXPORT_FILE_FORMATS = {

--- a/src/pickers/DatePicker.jsx
+++ b/src/pickers/DatePicker.jsx
@@ -52,6 +52,11 @@ class openIMISDatePicker extends Component {
       "Input.disabledVisibilityBoost",
       DEFAULT.DISABLED_VISIBILITY_BOOST,
     );
+    this.inputVariant = props.modulesManager.getConf(
+        "fe-core",
+        "Input.variant",
+        DEFAULT.INPUT_VARIANT,
+      );
   }
 
   state = {
@@ -138,6 +143,7 @@ class openIMISDatePicker extends Component {
       modulesManager,
       minDate,
       maxDate,
+      inputVariant,
       ...otherProps
     } = this.props;
 
@@ -173,7 +179,6 @@ class openIMISDatePicker extends Component {
     } else {
       return (
         <StyledDatePicker>
-          <FormControl fullWidth={fullWidth}>
             <LocalizationProvider dateAdapter={AdapterDayjs}>
               <MUIDatePicker
               {...otherProps}
@@ -191,9 +196,9 @@ class openIMISDatePicker extends Component {
               label={!!label ? formatMessage(intl, module, label).concat(required ? " *" : "") : null}
               onChange={this.dateChange}
               disablePast={disablePast}
+              variant={inputVariant}
               />
             </LocalizationProvider>
-          </FormControl>
         </StyledDatePicker>
       );
     }

--- a/src/pickers/DatePicker.jsx
+++ b/src/pickers/DatePicker.jsx
@@ -23,18 +23,22 @@ import gregorian from "react-date-object/calendars/gregorian";
 import gregorian_en from "react-date-object/locales/gregorian_en";
 
 const StyledDatePicker = styled('div')(({ theme }) => ({
-  '& .label': {
-    color: theme.palette.primary.main,
+  // Ensure custom (non-MUI) date pickers (e.g. secondary calendar) inherit theme colors
+  '& label': {
+    color: theme.palette.text.secondary,
+  },
+  '& input': {
+    color: theme.palette.text.primary,
   },
   '& .disabledStateVisibilityBoost': {
     "& .MuiFormLabel-root.Mui-disabled": {
-      color: "#181716",
+      color: theme.palette.text.secondary,
     },
     "& .MuiInputBase-input.Mui-disabled": {
-      color: "#5E5B50",
+      color: theme.palette.text.primary,
     },
     "& .MuiInput-underline:before": {
-      borderBottom: `1px dotted #5E5B50`,
+      borderBottom: `1px dotted ${theme.palette.text.disabled || theme.palette.divider}`,
     },
   },
 }));
@@ -155,7 +159,7 @@ class openIMISDatePicker extends Component {
       return (
         <StyledDatePicker>
           <FormControl fullWidth={fullWidth}>
-            <label className="label">
+            <label>
               {!!label ? formatMessage(intl, module, label).concat(required ? " *" : "") : null}
             </label>
             <DatePicker
@@ -190,9 +194,6 @@ class openIMISDatePicker extends Component {
                 "disabledStateVisibilityBoost": this.disabledVisibilityBoost && readOnly,
               })}
               value={this.state.value}
-              InputLabelProps={{
-                className: "label",
-              }}
               label={!!label ? formatMessage(intl, module, label).concat(required ? " *" : "") : null}
               onChange={this.dateChange}
               disablePast={disablePast}

--- a/src/pickers/DatePicker.jsx
+++ b/src/pickers/DatePicker.jsx
@@ -139,6 +139,7 @@ class openIMISDatePicker extends Component {
       module,
       label,
       readOnly = false,
+      disabled = false,
       required = false,
       fullWidth = true,
       format = "DD-MM-YYYY",
@@ -150,6 +151,12 @@ class openIMISDatePicker extends Component {
       inputVariant,
       ...otherProps
     } = this.props;
+
+    const toBool = (v) => {
+      if (v === false || v === "false" || v === 0 || v === "0" || v == null || v === "") return false;
+      return !!v;
+    };
+    const isDisabled = toBool(readOnly) || toBool(disabled);
 
     if (isSecondaryCalendarEnabled) {
       const secondCalendarFormatting = modulesManager.getConf("fe-core", "secondCalendarFormatting", format);
@@ -164,7 +171,7 @@ class openIMISDatePicker extends Component {
             </label>
             <DatePicker
               format={secondCalendarFormatting}
-              disabled={readOnly}
+              disabled={isDisabled}
               value={this.state.value ? this.moveByOneDay(new Date(this.state.value)) : null}
               {...((!!minDate || disablePast) && this.setMinDate())}
               {...(!!maxDate && { maxDate: this.moveByOneDay(new Date(maxDate)) })}
@@ -189,9 +196,9 @@ class openIMISDatePicker extends Component {
               maxDate={maxDate ? dayjs(maxDate) : undefined}
               minDate={minDate ? dayjs(minDate) : undefined}
               format={format}
-              disabled={readOnly}
+              disabled={isDisabled}
               className={clsx({
-                "disabledStateVisibilityBoost": this.disabledVisibilityBoost && readOnly,
+                "disabledStateVisibilityBoost": this.disabledVisibilityBoost && isDisabled,
               })}
               value={this.state.value}
               label={!!label ? formatMessage(intl, module, label).concat(required ? " *" : "") : null}


### PR DESCRIPTION

# Description
Allow users to set the default input variant (standard, outlined, filled) via Input.variant in the fe-core configuration. The variant is applied globally to MUI TextField, Select, FormControl, DatePicker, TimePicker, and DateTimePicker components. Update createAppTheme to accept the configuration and fall back to "standard" when not provided. Add documentation for the new configuration option.
A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires https://github.com/openimis/openimis-fe_js/pull/225
- [] https://openimis.atlassian.net/browse/OP-3079
- 
## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
