### PR TITLE
Fix OP-3088: Enable fetching on filter reset

### DIFF
--- a/src/components/generics/Searcher.jsx
+++ b/src/components/generics/Searcher.jsx
@@ -294,6 +294,7 @@ class Searcher extends Component {
     super(props);
     this.miniFilterPane = props.modulesManager.getConf("fe-core", "miniFilterPane", false);
     this.fetchEnabled = props.modulesManager.getConf("fe-core", "shouldFetchInitially", true);
+    this.searchOnResetFilters = props.modulesManager.getConf("fe-core", "shouldSearchOnResetFilters", true);
   }
   componentDidMount() {
     document.addEventListener("keypress", this.handleEnter);
@@ -357,7 +358,7 @@ class Searcher extends Component {
         filters: { ...this.props.defaultFilters },
         orderBy: props.defaultOrderBy,
       }),
-      (e) => this.applyFilters(),
+      (e) => !this.searchOnResetFilters ? null : this.applyFilters(),
     );
   };
 


### PR DESCRIPTION

# Description


New module configration : **shouldSearchOnResetFilters should be set to false or true , default true**
A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

https://github.com/user-attachments/assets/00db6b5f-87ae-4eba-bd56-3200226b3153


Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
