### PR TITLE
feat(core): implements fields max length service

### DIFF
--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -88,6 +88,15 @@ export function journalize(mutation, meta) {
   };
 }
 
+export function fetchMaxLengthConstraints() {
+  const payload = formatQuery("maxLengthConstraints", {}, ["constraints"]);
+  return graphql(payload, "FETCH_MAX_LENGTH_CONSTRAINTS");
+}
+
+function isCsrfError(error) {
+  return error?.message?.includes("CSRF token missing or incorrect.");
+}
+
 export function graphql(payload, type = "GRAPHQL_QUERY", params = {}) {
   let req = type + "_REQ";
   let resp = type + "_RESP";

--- a/src/admin/actions.js
+++ b/src/admin/actions.js
@@ -13,7 +13,6 @@ import { mapUserValuesToInput } from "./utils";
 const USER_SUMMARY_PROJECTION_BASE = [
   "id",
   "username",
-  "userTypes",
   "officer{id,dob,phone,lastName,otherNames,email}",
   "iUser{id,phone,lastName,otherNames,email,roles{id,name}}",
   "clientMutationId",

--- a/src/admin/components/UserMasterPanel.jsx
+++ b/src/admin/components/UserMasterPanel.jsx
@@ -153,6 +153,7 @@ const UserMasterPanel = (props) => {
       <TextInput
         module="admin"
         label="user.lastName"
+        maxLengthKey="admin.user.lastName"
         required
         readOnly={readOnly}
         value={edited?.lastName ?? ""}
@@ -166,6 +167,7 @@ const UserMasterPanel = (props) => {
       <TextInput
         module="admin"
         label="user.givenNames"
+        maxLengthKey="admin.user.otherNames"
         required
         readOnly={readOnly}
         value={edited?.otherNames ?? ""}
@@ -188,6 +190,7 @@ const UserMasterPanel = (props) => {
           setValidAction={setUsernameValid}
           module="admin"
           label="user.username"
+          maxLengthKey="admin.user.username"
           codeTakenLabel="user.usernameAlreadyTaken"
           required={true}
           value={edited?.username ?? ""}
@@ -227,6 +230,7 @@ const UserMasterPanel = (props) => {
             readOnly={readOnly}
             module="admin"
             label="user.email"
+            maxLengthKey="admin.user.email"
             type="email"
             codeTakenLabel="user.emailAlreadyTaken"
             required={true}
@@ -244,6 +248,7 @@ const UserMasterPanel = (props) => {
             module="admin"
             type="phone"
             label="user.phone"
+            maxLengthKey="admin.user.phone"
             required={
               obligatoryUserFields?.phone == "M" ||
               (edited.userTypes?.includes(ENROLMENT_OFFICER_USER_TYPE) && obligatoryEOFields?.phone == "M")

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -8,7 +8,7 @@ import withModulesManager, { ModulesManagerProvider } from "../helpers/modules";
 import Helmet from "../helpers/Helmet";
 import RequireAuth from "./RequireAuth";
 import FatalErrorPage from "./generics/FatalError";
-import { clearConfirm, toggleCurrentCalendarType } from "../actions";
+import { clearConfirm, toggleCurrentCalendarType, fetchMaxLengthConstraints } from "../actions";
 import AlertDialog from "./dialogs/AlertDialog";
 import ConfirmDialog from "./dialogs/ConfirmDialog";
 import { bindActionCreators } from "redux";
@@ -125,6 +125,7 @@ const App = (props) => {
         location.replace(basename);
       }
     }
+    dispatch(fetchMaxLengthConstraints());
   }, []);
 
   useEffect(() => {

--- a/src/components/inputs/TextInput.jsx
+++ b/src/components/inputs/TextInput.jsx
@@ -1,9 +1,10 @@
 import React, { Component } from "react";
 import clsx from "clsx";
+import { connect } from "react-redux";
 import { styled } from "@mui/material/styles";
 import { injectIntl } from "react-intl";
 import { TextField } from "@mui/material";
-import { formatMessage } from "../../helpers/i18n";
+import { formatMessage, formatMessageWithValues } from "../../helpers/i18n";
 import { DEFAULT } from "../../constants";
 import withModulesManager from "../../helpers/modules";
 
@@ -38,6 +39,9 @@ const StyledTextInput = styled("div")(({ theme }) => ({
   },
 }));
 
+const getNestedValue = (object, path) =>
+  path?.split(".").reduce((current, key) => current?.[key], object);
+
 class TextInput extends Component {
   constructor(props) {
     super(props);
@@ -50,6 +54,8 @@ class TextInput extends Component {
 
   state = {
     value: "",
+    maxLengthReached: false,
+    maxLength: null,
   };
   componentDidMount() {
     let value = this.props.value ?? "";
@@ -71,15 +77,56 @@ class TextInput extends Component {
       }
     }
   }
+
+  getMaxLength = () => {
+    const { constraints } = this.props.maxLengthConstraints || {};
+    const { inputProps = {}, label, maxLengthKey, module } = this.props;
+
+    if (inputProps.maxLength) {
+      return inputProps.maxLength;
+    }
+
+    if (maxLengthKey) {
+      return getNestedValue(constraints, maxLengthKey);
+    }
+
+    const labelParts = label?.split(".");
+    const field = labelParts?.[1];
+    const form = labelParts?.[0]?.toLowerCase();
+    const moduleConstraints = constraints?.[module];
+
+    return moduleConstraints?.[form]?.[field] || moduleConstraints?.[field];
+  };
+
   _onChange = (e) => {
     let { value } = e.target;
+
+    let maxLengthReached = false;
+    let maxLength = this.getMaxLength();
+
     if (this.props.formatInput) {
       value = this.props.formatInput(value);
     }
-    if (value !== this.state.value) {
-      this.setState({ value }, () => this.props.onChange && this.props.onChange(this.state.value));
+
+    if (maxLength && value.length > maxLength) {
+      value = value.slice(0, maxLength);
+      maxLengthReached = true;
+    } else if (maxLength && value.length >= maxLength) {
+      maxLengthReached = true;
     }
+
+    this.setState(
+      {
+        value,
+        maxLengthReached,
+        maxLength,
+      },
+      () => {
+        this.props.onChange?.(this.state.value);
+      }
+    );
   };
+
   render() {
     const {
       intl,
@@ -96,6 +143,11 @@ class TextInput extends Component {
       modulesManager,
       ...others
     } = this.props;
+
+    const maxLength = this.getMaxLength();
+    const effectiveInputProps = maxLength ? { ...inputProps, maxLength } : inputProps;
+    const err = error || this.state.maxLengthReached;
+    const msg = this.state.maxLengthReached ? formatMessageWithValues(this.props.intl, "core", "input.maxLengthReached", { max: this.state.maxLength }) : helperText;
     return (
       <StyledTextInput>
         <TextField
@@ -110,11 +162,11 @@ class TextInput extends Component {
           InputLabelProps={{
             className: "label",
           }}
-          InputProps={{ inputProps, startAdornment, endAdornment }}
+          InputProps={{ inputProps: effectiveInputProps, startAdornment, endAdornment }}
           onChange={this._onChange}
           value={this.state.value}
-          error={Boolean(error)}
-          helperText={error ?? helperText}
+          error={Boolean(err)}
+          helperText={msg}
           type={type}
         />
       </StyledTextInput>
@@ -122,5 +174,9 @@ class TextInput extends Component {
   }
 }
 
+const mapStateToProps = (state) => ({
+  maxLengthConstraints: state.core.maxLengthConstraints,
+});
+
 export { StyledTextInput };
-export default withModulesManager(injectIntl(TextInput));
+export default withModulesManager(connect(mapStateToProps)(injectIntl(TextInput)));

--- a/src/components/inputs/ValidatedTextInput.jsx
+++ b/src/components/inputs/ValidatedTextInput.jsx
@@ -38,6 +38,7 @@ const ValidatedTextInput = ({
   value,
   invalidValueFormatLabel,
   invalidValueFormat,
+  maxLengthKey,
 }) => {
   const modulesManager = useModulesManager();
 
@@ -84,6 +85,7 @@ const ValidatedTextInput = ({
           error={error}
           value={value}
           inputProps={inputProps}
+          maxLengthKey={maxLengthKey}
           endAdornment={
             <InputAdornment position="end" component={!error ? ValidIcon : InvalidIcon}>
               <>
@@ -111,6 +113,7 @@ const ValidatedTextInput = ({
           type={type}
           onChange={debounce(onChange, DEFAULT_DEBOUNCE_TIME)}
           inputProps={inputProps}
+          maxLengthKey={maxLengthKey}
           endAdornment={
             <InputAdornment position="end" component={!error ? ValidIcon : InvalidIcon}>
               <>

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -390,6 +390,28 @@ function reducer(
         fetchingCustomFilters: false,
         errorCustomFilters: formatServerError(action.payload),
       };
+    case "FETCH_MAX_LENGTH_CONSTRAINTS_REQ":
+      return {
+        ...state,
+        fetchingMaxLengthConstraints: true,
+        fetchedMaxLengthConstraints: false,
+        maxLengthConstraints: [],
+        errorMaxLengthConstraints: null,
+      };
+    case "FETCH_MAX_LENGTH_CONSTRAINTS_RESP":
+      return {
+        ...state,
+        fetchingMaxLengthConstraints: false,
+        fetchedMaxLengthConstraints: true,
+        maxLengthConstraints: action.payload?.data?.maxLengthConstraints || [],
+        errorMaxLengthConstraints: formatGraphQLError(action.payload),
+      };
+    case "FETCH_MAX_LENGTH_CONSTRAINTS_ERR":
+      return {
+        ...state,
+        fetchingMaxLengthConstraints: false,
+        errorMaxLengthConstraints: formatServerError(action.payload),
+      };
     case "CORE_ROLE_MUTATION_REQ":
       return dispatchMutationReq(state, action);
     case "CORE_ROLE_MUTATION_ERR":

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -237,5 +237,6 @@
   "core.back.buttonText": "Back",
   "roleManagement.editButton.buttonText": "Edit",
   "roleManagement.duplicateButton.buttonText": "Duplicate",
-  "roleManagement.deleteButton.buttonText": "Delete"
+  "roleManagement.deleteButton.buttonText": "Delete",
+  "input.maxLengthReached": "You have reached the maximum number of characters allowed for this field ({max})"
 }


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

In Openimis, several backend models enforce maximum field lengths (`max_length`). Consequently, when the frontend sends a payload with fields exceeding these limits, the backend returns an error message for the mutation. To prevent users from encountering this—given that the backend error message is not particularly user-friendly—we implemented a service that blocks further input once the `max_length` is reached and displays a message to inform the user (see screenshot).

The implemented approach is as follows:

On the backend, a new type is added to the queries: `MaxLengthConstraintsGQLType`

Expected payload:

`query GetMaxLengthConstraints {
  maxLengthConstraints {
    constraints
  }
}`

which returns something like:

`{
  "data": {
    "maxLengthConstraints": {
       "insuree": {
          "uuid": 36,
          "chfId": 50,
          "lastName": 100,
          "otherNames": 100,
          "marital": 1,
          "passport": 25,
          "phone": 50,
          "email": 100,
          "currentAddress": 200,
          "geolocation": 250,
          "status": 2
        }
       }
     }
   }`

On the frontend, this payload is retrieved, and component properties are used to identify the `max_length` for the current field and manage user interaction.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Enhancement

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-be-core_py/pull/431
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

<img width="1847" height="992" alt="Capture d’écran du 2026-06-30 00-08-27" src="https://github.com/user-attachments/assets/792d50cd-a4a6-439b-bbd8-4e4cde4f874b" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
