### PR TITLE
fix subserviceformatters size

### DIFF
--- a/src/components/generics/TableService.jsx
+++ b/src/components/generics/TableService.jsx
@@ -219,7 +219,6 @@ class Table extends Component {
       error = null,
       forReview,
       subServicesItemsFormatters,
-      subServicesItemsFormattersReview,
       subServiceHeaders,
     } = this.props;
     let localHeaders = [...(headers || [])];
@@ -227,7 +226,6 @@ class Table extends Component {
     let localPreHeaders = !!preHeaders ? [...preHeaders] : null;
     let localItemFormatters = [...itemFormatters];
     let localSubServicesItemsFormatters = [...(subServicesItemsFormatters || [])];
-    let localsubServicesItemsFormattersReview = [...(subServicesItemsFormattersReview || [])];
     var i = !!headers && headers.length;
     var localForReview = forReview;
     while (localHeaders && i--) {
@@ -285,9 +283,6 @@ class Table extends Component {
               {items &&
                 items.length > 0 &&
                 items.map((i, iidx) => {
-                  const activeSubFormatters = forReview
-                    ? localsubServicesItemsFormattersReview
-                    : localSubServicesItemsFormatters;
                   const showSubServices = this.shouldShowSubServices(i, iidx, localItemFormatters);
 
                   if (i.claimlinkedService != undefined) {
@@ -331,7 +326,7 @@ class Table extends Component {
                                 </TableCell>
                               ))}
                             </TableRow>
-                            {this.renderSubServiceRows(i, iidx, activeSubFormatters)}
+                            {this.renderSubServiceRows(i, iidx, localSubServicesItemsFormatters)}
                           </Fragment>
                         )}
                       </Fragment>
@@ -364,16 +359,19 @@ class Table extends Component {
                         )}
                       </TableRow>
                       {showSubServices && (
-                        <Fragment>
-                          <TableRow>
-                            {localSubServiceHeaders.map((h, idx) => (
-                              <TableCell key={`sub-header-${iidx}-${idx}`} className="tableHeader">
-                                <FormattedMessage module={module} id={h} />
-                              </TableCell>
-                            ))}
-                          </TableRow>
-                          {this.renderSubServiceRows(i, iidx, activeSubFormatters)}
-                        </Fragment>
+                        <TableRow>
+                          <TableCell colSpan={cleanedHeaders.length || 1}>
+                              <TableRow>
+                                {localSubServiceHeaders.map((h, idx) => (
+                                  <TableCell 
+                                  key={`sub-header-${iidx}-${idx}`} className="tableHeader">
+                                    <FormattedMessage module={module} id={h} />
+                                  </TableCell>
+                                ))}
+                              </TableRow>
+                            {this.renderSubServiceRows(i, iidx, localSubServicesItemsFormatters)}
+                          </TableCell>
+                        </TableRow>
                       )}
                     </Fragment>
                   );


### PR DESCRIPTION
# Description

The sub-services panel does not use the full available width. There is an empty space after the sub-service price column for rejected and checked claim
I refactored the `TableService` component so that the sub-services table is rendered as a separate table. As a result, the dimensions of its columns are now independent of the `itemFormatters` table.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="1364" height="542" alt="Screenshot 2026-07-09 at 10 16 26 AM" src="https://github.com/user-attachments/assets/6d9b069f-dde1-4316-b75c-fd205ddc6092" />


## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
