### PR TITLE
feat(error): support HTML formatted error messages

### DIFF
--- a/src/components/generics/Error.jsx
+++ b/src/components/generics/Error.jsx
@@ -10,20 +10,51 @@ const StyledError = styled('div')(({ theme }) => ({
   '& .errorDetail': {
     color: theme.palette.error.main,
   },
+  '& .errorlist': {
+    color: theme.palette.error.main,
+    margin: theme.spacing(1, 0, 1, 2),
+    paddingLeft: theme.spacing(2),
+    '& li': {
+      listStyleType: 'disc',
+    },
+    '& .errorlist': {
+      margin: theme.spacing(0.5, 0, 0.5, 2),
+    }
+  },
+  '& .errorlist > li': {
+    listStyleType: 'none',
+  },
+  '& .errorlist .errorlist > li': {
+    listStyleType: 'disc',
+  },
 }));
+
+// Fonction utilitaire pour détecter et rendre le HTML
+const renderHtmlContent = (content) => {
+  if (!content) return null;
+  
+  // Détecte si le contenu contient des balises HTML
+  const htmlRegex = /<[a-z][\s\S]*>/i;
+  if (htmlRegex.test(content)) {
+    return <span dangerouslySetInnerHTML={{ __html: content }} />;
+  }
+  return content;
+};
 
 function Error(props) {
   const { error } = props;
+
   return (
     <StyledError>
       <Typography variant="h6" className="errorHeader">
-        {error.code} {error.code && ": "} {error.message}
+        {error.code} {error.code && ": "} 
+        {renderHtmlContent(error.message)}
       </Typography>
       {!!error.detail && (
         <Fragment>
           <Divider />
           <Typography variant="body1" className="errorDetail">
-            {error.detail}
+            {renderHtmlContent(error.detail)}
           </Typography>
         </Fragment>
       )}


### PR DESCRIPTION
## Description

**Problem:** The Error component displays HTML error messages from the backend as raw text, making them unreadable for users.

**Solution:** Detect HTML content in `error.message` and `error.detail`, render it properly using `dangerouslySetInnerHTML` while keeping plain text messages unchanged. Added CSS styles for HTML error lists (`<ul class="errorlist">`).

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

- [x] External reference: [link to Jira ticket]

## Demo

| Before | After |
|--------|-------|
| ![HTML raw text](https://via.placeholder.com/400x150/ff6b6b/ffffff?text=Raw+HTML+Displayed) | ![HTML rendered](https://via.placeholder.com/400x150/51cf66/ffffff?text=Properly+Rendered+HTML) |
| Error displays as: `<ul class="errorlist"><li>subject_type<ul class="errorlist"><li>Invalid ID specified.</li></ul></li></ul>` | Error displays as: <br> • subject_type <br>&nbsp;&nbsp;&nbsp; ◦ Invalid ID specified. |

<img width="1795" height="882" alt="Capture d’écran du 2026-07-12 09-41-29" src="https://github.com/user-attachments/assets/a3ea0966-25aa-44b1-ba8e-012d4ba57188" />
<img width="1795" height="772" alt="Capture d’écran du 2026-07-12 09-41-12" src="https://github.com/user-attachments/assets/2a77d336-2eda-45b3-992c-0f46a1b5e702" />

## Checklist

- [ ] Unit tests added/modified
- [ ] I18n / translation handled