### PR TITLE
fix(OP-3095): remove direct state mutation on user object in user adm…

### DIFF
--- a/src/admin/actions.js
+++ b/src/admin/actions.js
@@ -107,9 +107,6 @@ export function createUser(mm, user, clientMutationLabel) {
     { clientMutationLabel },
   );
 
-  // eslint-disable-next-line no-param-reassign
-  user.clientMutationId = mutation.clientMutationId;
-
   return graphqlWithVariables(
     mutation.operation,
     mutation.variables,
@@ -132,9 +129,6 @@ export function updateUser(mm, user, clientMutationLabel) {
     { clientMutationLabel },
   );
 
-  // eslint-disable-next-line no-param-reassign
-  user.clientMutationId = mutation.clientMutationId;
-
   return graphqlWithVariables(
     mutation.operation,
     mutation.variables,
@@ -145,8 +139,6 @@ export function updateUser(mm, user, clientMutationLabel) {
 
 export function deleteUser(mm, user, clientMutationLabel) {
   const mutation = formatMutation("deleteUser", `uuids: ["${decodeId(user.id)}"]`, clientMutationLabel);
-  // eslint-disable-next-line no-param-reassign
-  user.clientMutationId = mutation.clientMutationId;
   return (dispatch) => {
     dispatch(
       graphql(mutation.payload, ["ADMIN_USER_MUTATION_REQ", "ADMIN_USER_DELETE_RESP", "ADMIN_USER_MUTATION_ERR"], {


### PR DESCRIPTION
…in actions

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description


**The Error:** user.clientMutationId = mutation.clientMutationId;

**Why it failed:** This module contained the exact same mutation bug as the Claim Sampling module. Whenever an administrator tried to create, edit, or delete a user, the action creator would try to attach an ID to the user object. Since that object is part of the Redux state, it triggered the same state mutation crash.
# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
