### PR TITLE
fix(core): fix all menus not visibles in main menu bar

### DIFF
--- a/src/components/MainMenuBar.jsx
+++ b/src/components/MainMenuBar.jsx
@@ -24,7 +24,7 @@ function getMenus(modulesManager, key, rights, menuVariant, history, intl) {
     if (!config.entries && !config.submenus && !config.contributionKey) {
       console.warn(`Menu ${config.id} has no entries or submenus or valid contributionKey.`);
     }
-    config.text = getMenuText(config.text, intl);
+    config.text = getMenuText(config.name || config.text, intl);
   });
   // Sort by position (default 99 if missing; stable for duplicates)
   const sortedMenuConfigs = unsortedMenuEntries.sort((a, b) => (a.position || 99) - (b.position || 99));


### PR DESCRIPTION
# Description

Menus in the main menu bar became invisible, as shown in the screenshot below. The issue was caused by the code referencing `config.text` instead of `config.name`.

To preserve backward compatibility, I updated the implementation to support both `config.name` and `config.text`.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

[Capture vidéo du 17-07-2026 13:12:34.webm](https://github.com/user-attachments/assets/197ca268-56e2-4936-ae5a-d730b6b79876)

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
