### PR TITLE
feat: add generic withHistory support to Searcher component

### DIFF
--- a/src/admin/translations/en.json
+++ b/src/admin/translations/en.json
@@ -16,6 +16,7 @@
   "admin.menu.users": "Users",
   "admin.menu.usersProfiles": "Users Profiles",
   "admin.showHistory": "Show historical values",
+  "admin.hideHistory": "Hide historical values",
   "admin.user.CreateUser.mutationLabel": "Create user",
   "admin.user.UserOverview.newTitle": "New User",
   "admin.user.UserOverview.title": "User Details",

--- a/src/components/generics/Searcher.jsx
+++ b/src/components/generics/Searcher.jsx
@@ -381,7 +381,8 @@ class Searcher extends Component {
       if (filter.value === null) {
         delete filters[filter.id];
       } else {
-        filters[filter.id] = { value: filter.value, filter: filter.filter };
+        // Fix: include id field in the assigned object to address PR review comment
+        filters[filter.id] = { id: filter.id, value: filter.value, filter: filter.filter };
       }
     });
     this.setState({ filters }, () => {

--- a/src/components/generics/Searcher.jsx
+++ b/src/components/generics/Searcher.jsx
@@ -384,7 +384,21 @@ class Searcher extends Component {
         filters[filter.id] = { value: filter.value, filter: filter.filter };
       }
     });
-    this.setState({ filters });
+    this.setState({ filters }, () => {
+      if (fltrs.some(f => f.id === 'showHistory')) {
+        this.applyFilters();
+      }
+    });
+  };
+
+  onShowHistory = (value) => {
+    this.onChangeFilters([
+      {
+        id: "showHistory",
+        value: value,
+        filter: `showHistory: ${value}`,
+      },
+    ]);
   };
 
   _notifyFiltersApplied = () => {
@@ -608,6 +622,7 @@ class Searcher extends Component {
       displayClearAllColsButton,
       infoButtonContent = "",
       searcherActionsPosition = "top-right",
+      withHistory = false,
     } = this.props;
     return (
       <StyledSearcher>
@@ -618,6 +633,8 @@ class Searcher extends Component {
             refresh={this.applyFilters}
             del={this.deleteFilter}
             filters={this.state.filters}
+            onShowHistory={withHistory ? this.onShowHistory : null}
+            showHistory={!!this.state.filters.showHistory?.value}
             filterPane={
               <FilterPane
                 filters={this.state.filters}

--- a/src/components/generics/SearcherPane.jsx
+++ b/src/components/generics/SearcherPane.jsx
@@ -7,6 +7,8 @@ import { styled } from "@mui/material/styles";
 import GetIconComponent from "../../helpers/icons";
 const ResetFilterIcon = GetIconComponent("YoutubeSearchedFor");
 const DefaultSearchIcon = GetIconComponent("Search");
+const HistoryIcon = GetIconComponent("History");
+const HistoryOffIcon = GetIconComponent("HistoryOff");
 
 import SearcherActionButton from "./SearcherActionButton";
 import { DEFAULT_DEBOUNCE_TIME, ENTER_KEY } from "../../constants";
@@ -107,6 +109,8 @@ class SearcherPane extends Component {
       appliedFiltersRowStructure = null,
       setAppliedFiltersRowStructure = null,
       applyNumberCircle = null,
+      onShowHistory,
+      showHistory,
       ActionButton = SearcherActionButton,
     } = this.props;
     return (
@@ -118,7 +122,7 @@ class SearcherPane extends Component {
                 <FormattedMessage module={module} id={title} />
               </Grid>
               <Grid className="paperHeader">
-                {(!!actions || !!refresh) && (
+                {(!!actions || !!refresh || !!onShowHistory) && (
                   <>
                     {isCustomFiltering === true ? (
                       <AdvancedFiltersDialog
@@ -147,6 +151,18 @@ class SearcherPane extends Component {
                           label={a.label || ""}
                         />
                       ))}
+                    {!!onShowHistory && (
+                      <ActionButton
+                        key="action-history"
+                        startIcon={showHistory ? <HistoryOffIcon /> : <HistoryIcon />}
+                        onClick={() => onShowHistory(!showHistory)}
+                        label={formatMessage(
+                          this.props.intl,
+                          "admin",
+                          showHistory ? "hideHistory" : "showHistory",
+                        )}
+                      />
+                    )}
                     {!!reset && (
                       <ActionButton
                         key="action-reset"


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

**What it solved:** It removed inconsistent, manually-coded "show history" checkboxes from filterThis change unifies the "Show Historical Values" logic across the system into a single, reliable toggle.
**What it solved:** It fixed inconsistent behavior where manual checkboxes in filter panels didn't always trigger a data refresh correctly and cluttered the UI.
Which components have generic history: This can be activated for any other searcher (like Users, Roles, or Insurees) by adding the withHistory prop.

Example:
       <Searcher
          module="insuree"
          cacheFiltersKey={cacheFiltersKey}
          FilterPane={InsureeFilter}
          filterPaneContributionsKey={filterPaneContributionsKey}
          items={insurees}
          itemsPageInfo={insureesPageInfo}
          fetchingItems={fetchingInsurees}
          fetchedItems={fetchedInsurees}
          errorItems={errorInsurees}
          contributionKey={INSUREE_SEARCHER_CONTRIBUTION_KEY}
          tableTitle={formatMessageWithValues(intl, "insuree", "insureeSummaries", { count })}
          rowsPerPageOptions={this.rowsPerPageOptions}
          defaultPageSize={this.defaultPageSize}
          fetch={this.isDefaultFetchInsureeActivated == false  && searchInitiated ? this.fetch : this.isDefaultFetchInsureeActivated == true ? this.fetch : () => {}}
          rowIdentifier={this.rowIdentifier}
          rowSecondaryHighlighted={this.rowSecondaryHighlighted}
          filtersToQueryParams={this.filtersToQueryParams}
          defaultOrderBy="chfId"
          headers={this.headers}
          itemFormatters={this.itemFormatters}
          sorts={this.sorts}
          rowDisabled={this.rowDisabled}
          rowLocked={this.rowLocked}
          onDoubleClick={(i) => !i.clientMutationId && onDoubleClick(i)}
          reset={this.state.reset}
          **withHistory**
        />


# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

demo
https://openimis.atlassian.net/browse/OP-3098?search_id=62cfbc9f-005d-48c4-9660-da762909b206
## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
