### PR TITLE
fix filter healthfacility

### DIFF
--- a/src/admin/components/UserFilter.jsx
+++ b/src/admin/components/UserFilter.jsx
@@ -266,7 +266,7 @@ class UserFilter extends Component {
                   <PublishedComponent
                     pubRef="location.HealthFacilityPicker"
                     withNull={true}
-                    value={this.filterValue("healthFacilityId") || ""}
+                    value={this.filterValue("healthFacility") || ""}
                     district={selectedDistrict}
                     onChange={(v) => {
                       onChangeFilters([


### PR DESCRIPTION
# Description

When filtering users by health facility (FOSA), the selected value is not displayed in the field after the search. However, the filter is applied correctly, and the search returns the expected results

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/0fddecb3-9b10-4f91-99e9-11cf46d1f001



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
