### PR TITLE
fix(auth): honor cookie session on boot instead of a localStorage gate

### DIFF
--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -279,7 +279,12 @@ export function graphqlMutation(
 }
 
 export function fetch(config) {
-  const csrfToken = getLocalStorage("csrfToken");
+  // `silent` suppresses the session-expiry dialog on 401 (for boot probes); it
+  // must not reach the RSAA action.
+  const { silent, ...rsaaConfig } = config;
+
+  // Cookie fallback lets a session authenticated outside /front (e.g. Django) pass CSRF.
+  const csrfToken = getLocalStorage("csrfToken") ?? getCsrfToken();
 
   return async (dispatch, getState) => {
     const state = getState();
@@ -289,13 +294,13 @@ export function fetch(config) {
     try {
       action = await dispatch({
         [RSAA]: {
-          ...config,
+          ...rsaaConfig,
           headers: {
             "Content-Type": "application/json",
             "X-Requested-With": "XMLHttpRequest",
             "X-CSRFToken": csrfToken,
             ...(impersonatedUser && { "X-Impersonate-User": decodeId(impersonatedUser.id) }),
-            ...config.headers,
+            ...rsaaConfig.headers,
           },
         },
       });
@@ -315,7 +320,7 @@ export function fetch(config) {
 
       if (isSessionError(status, gqlErrors)) {
         dispatch({ type: "CORE_STOP_IMPERSONATION" });
-        if (isUnauthenticatedRoute()) {
+        if (isUnauthenticatedRoute() || silent) {
           clearExpiredSession();
           dispatch({ type: "CORE_AUTH_LOGOUT" });
         } else {
@@ -402,10 +407,11 @@ export function fetch(config) {
   };
 }
 
-export function loadUser() {
+export function loadUser(options = {}) {
   return fetch({
     endpoint: `${baseApiUrl}/core/users/current_user/`,
     method: "GET",
+    silent: options.silent,
     types: ["CORE_USERS_CURRENT_USER_REQ", "CORE_USERS_CURRENT_USER_RESP", "CORE_USERS_CURRENT_USER_ERR"],
   });
 }
@@ -554,12 +560,28 @@ export function refreshAuthToken() {
 
 export function initialize() {
   return async (dispatch) => {
-    if (isUnauthenticatedRoute() || !hasStoredAuthSession()) {
+    if (isUnauthenticatedRoute()) {
       dispatch({ type: "CORE_AUTH_LOGOUT" });
       return dispatch({ type: "CORE_INITIALIZED" });
     }
 
-    await dispatch(login());
+    // Silent probe: a valid auth cookie (/front JWT or Django session)
+    // authenticates; an anonymous boot logs out without the expiry dialog.
+    const action = await dispatch(loadUser({ silent: true }));
+    const status = action?.payload?.response?.status ?? action?.payload?.status;
+    const errors = action?.payload?.errors || action?.payload?.response?.errors || [];
+
+    if (action?.error || isSessionError(status, errors)) {
+      await clearExpiredSession();
+      dispatch({ type: "CORE_AUTH_LOGOUT" });
+    } else if (!getLocalStorage("csrfToken")) {
+      // Mirror the csrftoken cookie so later mutations send a matching X-CSRFToken.
+      const cookieCsrf = getCsrfToken();
+      if (cookieCsrf) {
+        setLocalStorage("csrfToken", cookieCsrf);
+      }
+    }
+
     return dispatch({ type: "CORE_INITIALIZED" });
   };
 }

--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -59,11 +59,11 @@ function getCsrfToken() {
     return CSRF_NOT_FOUND;
   }
 
-  const cookies = document.cookie;
-  const cookieArray = cookies.split("; ");
+  const prefix = `${CSRF_TOKEN_NAME}=`;
+  const cookieArray = document.cookie.split("; ");
 
-  const csrfCookie = cookieArray.find((cookie) => cookie.startsWith(CSRF_TOKEN_NAME));
-  return csrfCookie?.split("=")[1] ?? CSRF_NOT_FOUND;
+  const csrfCookie = cookieArray.find((cookie) => cookie.startsWith(prefix));
+  return csrfCookie ? csrfCookie.slice(prefix.length) : CSRF_NOT_FOUND;
 }
 
 export function apiHeaders() {

--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -12,7 +12,7 @@ import {
 } from "./helpers/api";
 import * as Sentry from "@sentry/react";
 import { getLocalStorage, setLocalStorage } from "./helpers/useLocalStorage";
-import { isSessionError, clearExpiredSession, hasStoredAuthSession, isImpersonationError } from "./helpers/api";
+import { isSessionError, clearExpiredSession, isImpersonationError } from "./helpers/api";
 import { isUnauthenticatedRoute, redirectToLogin } from "./helpers/utils";
 
 const REQUESTED_WITH = "webapp";
@@ -484,40 +484,6 @@ export function login(credentials) {
         dispatch(authError({ message: error.message }));
         return { loginStatus: "CORE_AUTH_ERR", message: error.message };
       }
-    } else {
-      if (!hasStoredAuthSession()) {
-        dispatch({ type: "CORE_AUTH_LOGOUT" });
-        return { loginStatus: "CORE_AUTH_LOGOUT", message: "" };
-      }
-
-      const refreshResult = await dispatch(refreshAuthToken());
-      const refreshStatus = refreshResult?.payload?.response?.status;
-      const refreshErrors = refreshResult?.payload?.errors || refreshResult?.payload?.response?.errors || [];
-
-      if (refreshResult?.error || isSessionError(refreshStatus, refreshErrors)) {
-        dispatch({ type: "CORE_STOP_IMPERSONATION" });
-        await clearExpiredSession();
-        dispatch({ type: "CORE_AUTH_LOGOUT" });
-        return { loginStatus: "CORE_AUTH_LOGOUT", message: "" };
-      }
-
-      const action = await dispatch(loadUser());
-      const loadUserStatus = action?.payload?.response?.status ?? action?.payload?.status;
-      const loadUserErrors = action?.payload?.errors || action?.payload?.response?.errors || [];
-
-      if (action?.error || action.type === "CORE_USERS_CURRENT_USER_ERR") {
-        if (isSessionError(loadUserStatus, loadUserErrors)) {
-          dispatch({ type: "CORE_STOP_IMPERSONATION" });
-          await clearExpiredSession();
-          dispatch({ type: "CORE_AUTH_LOGOUT" });
-          return { loginStatus: "CORE_AUTH_LOGOUT", message: "" };
-        }
-      }
-
-      return {
-        loginStatus: action.type,
-        message: action?.payload?.response?.detail ?? "Error occurred while loading user.",
-      };
     }
   };
 }

--- a/src/actions.jsx
+++ b/src/actions.jsx
@@ -55,6 +55,10 @@ function getCsrfToken() {
   const CSRF_TOKEN_NAME = "csrftoken";
   const CSRF_NOT_FOUND = null;
 
+  if (typeof document === "undefined") {
+    return CSRF_NOT_FOUND;
+  }
+
   const cookies = document.cookie;
   const cookieArray = cookies.split("; ");
 
@@ -321,7 +325,7 @@ export function fetch(config) {
       if (isSessionError(status, gqlErrors)) {
         dispatch({ type: "CORE_STOP_IMPERSONATION" });
         if (isUnauthenticatedRoute() || silent) {
-          clearExpiredSession();
+          await clearExpiredSession();
           dispatch({ type: "CORE_AUTH_LOGOUT" });
         } else {
           dispatch(
@@ -531,17 +535,12 @@ export function initialize() {
       return dispatch({ type: "CORE_INITIALIZED" });
     }
 
-    // Silent probe: a valid auth cookie (/front JWT or Django session)
-    // authenticates; an anonymous boot logs out without the expiry dialog.
+    // Silent probe: a valid auth cookie (/front JWT or Django session) loads the
+    // user; on success, mirror the csrftoken cookie for later mutations. Errors
+    // are handled downstream (401/403 clears the user, 5xx preserves state).
     const action = await dispatch(loadUser({ silent: true }));
-    const status = action?.payload?.response?.status ?? action?.payload?.status;
-    const errors = action?.payload?.errors || action?.payload?.response?.errors || [];
 
-    if (action?.error || isSessionError(status, errors)) {
-      await clearExpiredSession();
-      dispatch({ type: "CORE_AUTH_LOGOUT" });
-    } else if (!getLocalStorage("csrfToken")) {
-      // Mirror the csrftoken cookie so later mutations send a matching X-CSRFToken.
+    if (!action?.error && !getLocalStorage("csrfToken")) {
       const cookieCsrf = getCsrfToken();
       if (cookieCsrf) {
         setLocalStorage("csrfToken", cookieCsrf);

--- a/src/helpers/api.jsx
+++ b/src/helpers/api.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import _ from "lodash-uuid";
 import { IconButton } from "@mui/material";
 import GetIconComponent from "./icons";
-import { clearLocalStorage, getLocalStorage } from "./useLocalStorage";
+import { clearLocalStorage } from "./useLocalStorage";
 
 const SortIcon = GetIconComponent("UnfoldMore");
 const SortAscIcon = GetIconComponent("ExpandLess");
@@ -205,13 +205,6 @@ export const normalizeGraphqlErrorMessage = (message) =>
     .toLowerCase()
     .replace(/['"]/g, "")
     .trim();
-
-export const hasStoredAuthSession = () => {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return Boolean(getLocalStorage("csrfToken"));
-};
 
 export const isSessionError = (status, gqlErrors = []) => {
   if (status === 401) {


### PR DESCRIPTION
## Why

`initialize()` decided authentication from a client-side localStorage marker (`hasStoredAuthSession`) and skipped the session check entirely when it was absent. That is an unnecessary client-side gate, and it locks out any valid auth cookie that lacks the marker — notably a **Django session**, which left `/front` showing the login screen even when the user was authenticated.

The server is the real source of truth for auth; the marker was an unexamined optimization to avoid a boot-time request.

## What

- **Probe the server on boot** (safe `GET current_user`, no CSRF needed) instead of trusting the marker: a valid cookie — the `/front` JWT **or** a Django session — authenticates; an anonymous boot logs out. The probe is silent, so it never pops the session-expiry dialog.
- **`X-CSRFToken` falls back to the `csrftoken` cookie**, so mutations from a Django session pass CSRF without a `/front` login.
- Remove the now-dead no-arg `login()` branch and the `hasStoredAuthSession` helper (its only caller).

## Verified

`admin.cy.js` (openimis-dist_dkr), which logs into the Django admin then uses `/front`, now passes — including *Configures menu* and the individual-schema test — against a dev build with this change. (A third case fails on pre-existing leftover E2E data, unrelated to this PR.)