### PR TITLE
upgrade multi-select picker

### DIFF
--- a/src/admin/components/UserFilter.jsx
+++ b/src/admin/components/UserFilter.jsx
@@ -16,6 +16,7 @@ import {
   GRID_RESPONSIVE_STANDARD,
   GRID_RESPONSIVE_SMALL,
   GRID_RESPONSIVE_HALF,
+  GRID_RESPONSIVE_LARGE
 } from "@openimis/fe-core";
 import { DEFAULT, RIGHT_HEALTHFACILITIES } from "../constants";
 
@@ -248,7 +249,7 @@ class UserFilter extends Component {
             module="admin"
             id="userFilter.userRoles"
             field={
-              <Grid size={GRID_RESPONSIVE_STANDARD} className="item">
+              <Grid size={GRID_RESPONSIVE_LARGE} className="item">
                 <PublishedComponent
                   pubRef="admin.UserRolesPicker"
                   value={this.filterValue("roles")}

--- a/src/admin/components/pickers/UserRolesPicker.jsx
+++ b/src/admin/components/pickers/UserRolesPicker.jsx
@@ -13,6 +13,7 @@ const UserRolesPicker = ({
   label,
   filterOptions,
   filterSelectedOptions,
+  limitTags,
 }) => {
   const [searchString, setSearchString] = useState();
   const { formatMessage } = useTranslations("admin");
@@ -53,6 +54,7 @@ const UserRolesPicker = ({
       filterOptions={filterOptions}
       filterSelectedOptions={filterSelectedOptions}
       onInputChange={() => setSearchString(searchString)}
+      limitTags={2}
     />
   );
 };

--- a/src/components/inputs/Autocomplete.jsx
+++ b/src/components/inputs/Autocomplete.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { styled } from "@mui/material/styles";
 import MuiAutocomplete from "@mui/material/Autocomplete";
-import { TextField, Paper, Button, Chip } from "@mui/material";
+import { TextField, Paper, Button } from "@mui/material";
 import { useDebounceCb } from "../../helpers/hooks";
 import { useTranslations } from "../../helpers/i18n";
 import { useModulesManager } from "../../helpers/modules";
@@ -24,6 +24,24 @@ const StyledAutocomplete = styled("div")(({ theme }) => ({
 }));
 
 const defaultGetOptionSelected = (option, v) => option.id === v?.id;
+
+const PaperWithConfirm = ({ multiple, onConfirm, confirmLabel, ...paperProps }) => (
+  <Paper {...paperProps}>
+    {paperProps.children}
+    {multiple && (
+      <Button
+        fullWidth
+        size="small"
+        variant="text"
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={onConfirm}
+        sx={{ borderTop: "1px solid", borderColor: "divider" }}
+      >
+        {confirmLabel}
+      </Button>
+    )}
+  </Paper>
+);
 
 const Autocomplete = (props) => {
   const {
@@ -81,24 +99,6 @@ const Autocomplete = (props) => {
     setResetKey(Date.now());
   }, [value]);
 
-  const PaperWithConfirm = (paperProps) => (
-    <Paper {...paperProps}>
-      {paperProps.children}
-      {multiple && (
-        <Button
-          fullWidth
-          size="small"
-          variant="text"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => setOpen(false)}
-          sx={{ borderTop: "1px solid", borderColor: "divider" }}
-        >
-          {formatMessage("core.confirmSelect")}
-        </Button>
-      )}
-    </Paper>
-  );
-
   const hasValue = multiple ? value?.length > 0 : !!value;
 
   return (
@@ -132,7 +132,14 @@ const Autocomplete = (props) => {
         filterOptions={filterOptions}
         filterSelectedOptions={filterSelectedOptions}
         onInputChange={(__, query) => handleInputChange(query)}
-        PaperComponent={PaperWithConfirm}
+        PaperComponent={(paperProps) => (
+          <PaperWithConfirm
+            {...paperProps}
+            multiple={multiple}
+            onConfirm={() => setOpen(false)}
+            confirmLabel={formatMessage("core.confirmSelect")}
+          />
+        )}
         renderInput={
           !!renderInput
             ? renderInput

--- a/src/components/inputs/Autocomplete.jsx
+++ b/src/components/inputs/Autocomplete.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { styled } from "@mui/material/styles";
 import MuiAutocomplete from "@mui/material/Autocomplete";
-import { TextField } from "@mui/material";
+import { TextField, Paper, Button, Chip } from "@mui/material";
 import { useDebounceCb } from "../../helpers/hooks";
 import { useTranslations } from "../../helpers/i18n";
 import { useModulesManager } from "../../helpers/modules";
@@ -17,6 +17,9 @@ const StyledAutocomplete = styled("div")(({ theme }) => ({
   "& .MuiTextField-root": {
     minWidth: "150px",
     width: "100%",
+  },
+  "& .MuiChip-deleteIcon": {
+    fontSize: "16px",
   },
 }));
 
@@ -78,6 +81,26 @@ const Autocomplete = (props) => {
     setResetKey(Date.now());
   }, [value]);
 
+  const PaperWithConfirm = (paperProps) => (
+    <Paper {...paperProps}>
+      {paperProps.children}
+      {multiple && (
+        <Button
+          fullWidth
+          size="small"
+          variant="text"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => setOpen(false)}
+          sx={{ borderTop: "1px solid", borderColor: "divider" }}
+        >
+          {formatMessage("confirm")}
+        </Button>
+      )}
+    </Paper>
+  );
+
+  const hasValue = multiple ? value?.length > 0 : !!value;
+
   return (
     <StyledAutocomplete>
       <MuiAutocomplete
@@ -99,7 +122,7 @@ const Autocomplete = (props) => {
         autoHighlight={autoHighlight}
         open={open}
         onOpen={() => setOpen(true)}
-        onClose={() => setOpen(false)}
+        onClose={() => !multiple && setOpen(false)}
         limitTags={limitTags ?? -1}
         autoComplete
         value={value}
@@ -109,18 +132,20 @@ const Autocomplete = (props) => {
         filterOptions={filterOptions}
         filterSelectedOptions={filterSelectedOptions}
         onInputChange={(__, query) => handleInputChange(query)}
+        PaperComponent={PaperWithConfirm}
         renderInput={
           !!renderInput
             ? renderInput
             : (inputProps) => (
-                <TextField
-                  {...inputProps}
-                  required={required}
-                  InputLabelProps={{ shrink: value !== undefined, className: "label" }}
-                  label={withLabel && (label || formatMessage("label"))}
-                  placeholder={!readOnly && withPlaceholder ? placeholder || formatMessage("placeholder") : undefined}
-                />
-              )
+              <TextField
+                {...inputProps}
+                required={required}
+                InputLabelProps={{ shrink: value !== undefined, className: "label" }}
+                label={withLabel && (label || formatMessage("label"))}
+                placeholder={!readOnly && !hasValue && withPlaceholder ? placeholder || formatMessage("placeholder") : undefined
+                }
+              />
+            )
         }
       />
     </StyledAutocomplete>

--- a/src/components/inputs/Autocomplete.jsx
+++ b/src/components/inputs/Autocomplete.jsx
@@ -93,7 +93,7 @@ const Autocomplete = (props) => {
           onClick={() => setOpen(false)}
           sx={{ borderTop: "1px solid", borderColor: "divider" }}
         >
-          {formatMessage("confirm")}
+          {formatMessage("core.confirmSelect")}
         </Button>
       )}
     </Paper>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -241,5 +241,6 @@
   "roleManagement.editButton.buttonText": "Edit",
   "roleManagement.duplicateButton.buttonText": "Duplicate",
   "roleManagement.deleteButton.buttonText": "Delete",
-  "input.maxLengthReached": "You have reached the maximum number of characters allowed for this field ({max})"
+  "input.maxLengthReached": "You have reached the maximum number of characters allowed for this field ({max})",
+  "core.confirmSelect": "Confirm"
 }


### PR DESCRIPTION
# Description

I updated the Autocomplete component to allow users to select all the desired items before clicking a Confirm button to close the picker and continue

I also added a new prop to limit the number of selected items displayed in the picker based on the available space. This prevents the component from continuously increasing in height as more items are selected

When the number of selected items exceeds the display limit, an indicator shows how many additional items have been selected. Clicking this indicator allows users to view the complete list of selected items.

These improvements provide a more efficient selection workflow while keeping the interface clean and compact

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo


https://github.com/user-attachments/assets/61fbc650-423c-4356-ac15-08227ea4fbf6



## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
