### PR TITLE
fix(core): allow validated inputs to show validation error as helper …

### DIFF
--- a/src/components/inputs/ValidatedTextInput.jsx
+++ b/src/components/inputs/ValidatedTextInput.jsx
@@ -39,6 +39,7 @@ const ValidatedTextInput = ({
   invalidValueFormatLabel,
   invalidValueFormat,
   maxLengthKey,
+  showValidationErrorAsHelperText = false,
 }) => {
   const modulesManager = useModulesManager();
 
@@ -83,6 +84,7 @@ const ValidatedTextInput = ({
           placeholder={placeholder}
           type={type}
           error={error}
+          helperText={showValidationErrorAsHelperText ? error : null}
           value={value}
           inputProps={inputProps}
           maxLengthKey={maxLengthKey}
@@ -109,6 +111,7 @@ const ValidatedTextInput = ({
           value={value}
           readOnly={readOnly}
           error={error}
+          helperText={showValidationErrorAsHelperText ? error : null}
           required={required}
           type={type}
           onChange={debounce(onChange, DEFAULT_DEBOUNCE_TIME)}


### PR DESCRIPTION
# Description

This PR adds an optional `showValidationErrorAsHelperText` prop to `ValidatedTextInput`.

When enabled, validation errors are displayed as helper text under the input instead of only marking the field as invalid. The default behavior remains unchanged, so existing usages are not affected.

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [x] Enhancements

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

<img width="901" height="500" alt="Capture d’écran du 2026-07-28 12-11-07" src="https://github.com/user-attachments/assets/f6745af1-3571-43c8-969f-09d9864c7f57" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
