### PR TITLE
feat(core): add expandable detail rows support to generic Searcher table

### DIFF
--- a/src/components/generics/Searcher.jsx
+++ b/src/components/generics/Searcher.jsx
@@ -572,6 +572,8 @@ class Searcher extends Component {
       fetchedItems,
       errorItems,
       itemFormatters,
+      detailRowFormatter = null,
+      onRowClick = null,
       onDoubleClick,
       actions,
       processing = false,
@@ -715,6 +717,8 @@ class Searcher extends Component {
                     headerActions={this.headerActions(this.state.filters)}
                     aligns={!!aligns && aligns()}
                     itemFormatters={itemFormatters(this.state.filters)}
+                    detailRowFormatter={detailRowFormatter}
+                    onRowClick={onRowClick}
                     rowLocked={(i) => rowLocked(this.state.selection, i)}
                     rowHighlighted={(i) => rowHighlighted(this.state.selection, i)}
                     rowHighlightedAlt={(i) => rowHighlightedAlt(this.state.selection, i)}

--- a/src/components/generics/Table.jsx
+++ b/src/components/generics/Table.jsx
@@ -224,6 +224,8 @@ class Table extends Component {
       colSpans = [],
       items,
       itemFormatters,
+      detailRowFormatter = null,
+      onRowClick = null,
       rowHighlighted = null,
       rowHighlightedAlt = null,
       rowSecondaryHighlighted = null,
@@ -373,70 +375,81 @@ class Table extends Component {
               {items &&
                 items.length > 0 &&
                 items.map((i, iidx) => (
-                  <TableRow
-                    key={iidx}
-                    selected={this.isSelected(i)}
-                    onClick={(e) => !selectWithCheckbox && this.select(i, e)}
-                    onContextMenu={onDoubleClick ? () => onDoubleClick(i, true) : undefined}
-                    onDoubleClick={onDoubleClick ? () => onDoubleClick(i) : undefined}
-                    className={clsx(
-                      "tableRow",
-                      !!rowLocked && rowLocked(i) ? "tableLockedRow" : null,
-                      !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedRow" : null,
-                      !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltRow" : null,
-                      !!rowSecondaryHighlighted && rowSecondaryHighlighted(i) ? "tableSecondaryHighlightedRow" : null,
-                      !!rowDisabled && rowDisabled(i) ? "tableDisabledRow" : null,
-                      !!onDoubleClick && "clickable",
+                  <React.Fragment key={iidx}>
+                    <TableRow
+                      selected={this.isSelected(i)}
+                      onClick={(e) => {
+                        !selectWithCheckbox && this.select(i, e);
+                        onRowClick?.(i, e);
+                      }}
+                      onContextMenu={onDoubleClick ? () => onDoubleClick(i, true) : undefined}
+                      onDoubleClick={onDoubleClick ? () => onDoubleClick(i) : undefined}
+                      className={clsx(
+                        "tableRow",
+                        !!rowLocked && rowLocked(i) ? "tableLockedRow" : null,
+                        !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedRow" : null,
+                        !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltRow" : null,
+                        !!rowSecondaryHighlighted && rowSecondaryHighlighted(i) ? "tableSecondaryHighlightedRow" : null,
+                        !!rowDisabled && rowDisabled(i) ? "tableDisabledRow" : null,
+                        (!!onDoubleClick || !!onRowClick) && "clickable",
+                      )}
+                    >
+                      {selectWithCheckbox && withSelection && (
+                        <TableCell padding="checkbox">
+                          <Checkbox checked={this.isSelected(i)} onChange={(e) => this.select(i, e)} color="primary" />
+                        </TableCell>
+                      )}
+                      {showOrdinalNumber && (
+                        <TableCell
+                          className={clsx(
+                            !!rowLocked && rowLocked(i) ? "tableLockedCell" : null,
+                            !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedCell" : null,
+                            !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltCell" : null,
+                            !!rowSecondaryHighlighted && rowSecondaryHighlighted(i)
+                              ? "tableSecondaryHighlightedCell"
+                              : null,
+                            !!rowDisabled && rowDisabled(i) ? "tableDisabledCell" : null,
+                            aligns.length > 0 && aligns[0],
+                          )}
+                          key={`v-${this.calculateOrdinalNumber(iidx, withPagination)}-0`}
+                        >
+                          <span>{this.calculateOrdinalNumber(iidx, withPagination)}</span>
+                        </TableCell>
+                      )}
+                      {localItemFormatters &&
+                        localItemFormatters.map((f, fidx) => {
+                          if (colSpans.length > fidx && !colSpans[fidx]) return null;
+                          // NOTE: The 'f' function can explicitly be set to null, enabling the option to omit
+                          // a column  and suppress its display under specific conditions.
+                          if (f === null) return null;
+                          return (
+                            <TableCell
+                              colSpan={colSpans.length > fidx ? colSpans[fidx] : 1}
+                              className={clsx(
+                                !!rowLocked && rowLocked(i) ? "tableLockedCell" : null,
+                                !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedCell" : null,
+                                !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltCell" : null,
+                                !!rowSecondaryHighlighted && rowSecondaryHighlighted(i)
+                                  ? "tableSecondaryHighlightedCell"
+                                  : null,
+                                !!rowDisabled && rowDisabled(i) ? "tableDisabledCell" : null,
+                                aligns.length > fidx && aligns[fidx],
+                              )}
+                              key={`v-${iidx}-${fidx}`}
+                            >
+                              {f(i, iidx)}
+                            </TableCell>
+                          );
+                        })}
+                    </TableRow>
+                    {!!detailRowFormatter && detailRowFormatter(i, iidx) && (
+                      <TableRow>
+                        <TableCell colSpan={localItemFormatters.length + (selectWithCheckbox ? 1 : 0) + (showOrdinalNumber ? 1 : 0)}>
+                          {detailRowFormatter(i, iidx)}
+                        </TableCell>
+                      </TableRow>
                     )}
-                  >
-                    {selectWithCheckbox && withSelection && (
-                      <TableCell padding="checkbox">
-                        <Checkbox checked={this.isSelected(i)} onChange={(e) => this.select(i, e)} color="primary" />
-                      </TableCell>
-                    )}
-                    {showOrdinalNumber && (
-                      <TableCell
-                        className={clsx(
-                          !!rowLocked && rowLocked(i) ? "tableLockedCell" : null,
-                          !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedCell" : null,
-                          !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltCell" : null,
-                          !!rowSecondaryHighlighted && rowSecondaryHighlighted(i)
-                            ? "tableSecondaryHighlightedCell"
-                            : null,
-                          !!rowDisabled && rowDisabled(i) ? "tableDisabledCell" : null,
-                          aligns.length > 0 && aligns[0],
-                        )}
-                        key={`v-${this.calculateOrdinalNumber(iidx, withPagination)}-0`}
-                      >
-                        <span>{this.calculateOrdinalNumber(iidx, withPagination)}</span>
-                      </TableCell>
-                    )}
-                    {localItemFormatters &&
-                      localItemFormatters.map((f, fidx) => {
-                        if (colSpans.length > fidx && !colSpans[fidx]) return null;
-                        // NOTE: The 'f' function can explicitly be set to null, enabling the option to omit
-                        // a column  and suppress its display under specific conditions.
-                        if (f === null) return null;
-                        return (
-                          <TableCell
-                            colSpan={colSpans.length > fidx ? colSpans[fidx] : 1}
-                            className={clsx(
-                              !!rowLocked && rowLocked(i) ? "tableLockedCell" : null,
-                              !!rowHighlighted && rowHighlighted(i) ? "tableHighlightedCell" : null,
-                              !!rowHighlightedAlt && rowHighlightedAlt(i) ? "tableHighlightedAltCell" : null,
-                              !!rowSecondaryHighlighted && rowSecondaryHighlighted(i)
-                                ? "tableSecondaryHighlightedCell"
-                                : null,
-                              !!rowDisabled && rowDisabled(i) ? "tableDisabledCell" : null,
-                              aligns.length > fidx && aligns[fidx],
-                            )}
-                            key={`v-${iidx}-${fidx}`}
-                          >
-                            {f(i, iidx)}
-                          </TableCell>
-                        );
-                      })}
-                  </TableRow>
+                  </React.Fragment>
                 ))}
             </TableBody>
             {!!withPagination && !!count && (


### PR DESCRIPTION
# Description

## Summary

This PR updates `CoreModule` generic search/table components to support expandable detail rows rendered inline, directly beneath the selected row.

## Changes

- adds support for `detailRowFormatter` in the generic `Table`
- renders detail content as an inline table row under the related item
- adds support for `onRowClick` propagation through `Searcher` to `Table`
- marks clickable rows with the appropriate pointer cursor when row interaction is enabled

## Why

This was needed by `LedgerModule` so ledger entry details can expand inside the main results table, instead of being rendered outside or below the whole table.

## Impact

- reusable improvement in `CoreModule`
- enables row-based expandable detail patterns for other frontend modules
- no intended behavior change for existing searchers that do not use `detailRowFormatter` or `onRowClick`

## Validation

Validated through the Ledger frontend integration and unit tests using the updated generic behavior.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
